### PR TITLE
Add reaction-based feedback

### DIFF
--- a/app/penny/channels/signal/channel.py
+++ b/app/penny/channels/signal/channel.py
@@ -307,6 +307,28 @@ class SignalChannel(MessageChannel):
             return None
 
         sender = envelope.envelope.source
+
+        # Check if this is a reaction
+        if envelope.envelope.dataMessage.reaction:
+            reaction = envelope.envelope.dataMessage.reaction
+            if reaction.isRemove:
+                logger.debug("Ignoring reaction removal from %s", sender)
+                return None
+
+            logger.info(
+                "Extracted reaction - sender: %s, emoji: %s, target: %s",
+                sender,
+                reaction.emoji.value,
+                reaction.targetSentTimestamp,
+            )
+            return IncomingMessage(
+                sender=sender,
+                content=reaction.emoji.value,
+                is_reaction=True,
+                reacted_to_external_id=str(reaction.targetSentTimestamp),
+            )
+
+        # Regular text message
         content = envelope.envelope.dataMessage.message.strip()
 
         logger.info("Extracted - sender: %s, content: '%s'", sender, content)

--- a/app/penny/channels/signal/models.py
+++ b/app/penny/channels/signal/models.py
@@ -25,15 +25,35 @@ class Quote(BaseModel):
         populate_by_name = True
 
 
+class ReactionEmoji(BaseModel):
+    """Emoji used in a reaction."""
+
+    value: str  # The emoji unicode character
+
+
+class Reaction(BaseModel):
+    """Reaction message from Signal."""
+
+    emoji: ReactionEmoji
+    targetAuthor: str = Field(alias="targetAuthor")
+    targetAuthorNumber: str = Field(alias="targetAuthorNumber")
+    targetSentTimestamp: int = Field(alias="targetSentTimestamp")
+    isRemove: bool = Field(default=False, alias="isRemove")
+
+    class Config:
+        populate_by_name = True
+
+
 class DataMessage(BaseModel):
     """Data message from Signal."""
 
     timestamp: int
-    message: str
+    message: str = ""  # Empty for reactions
     expiresInSeconds: int = Field(default=0, alias="expiresInSeconds")
     isExpirationUpdate: bool = Field(default=False, alias="isExpirationUpdate")
     viewOnce: bool = Field(default=False, alias="viewOnce")
     quote: Quote | None = None
+    reaction: Reaction | None = None
 
     class Config:
         populate_by_name = True
@@ -59,6 +79,7 @@ class InnerEnvelope(BaseModel):
     serverDeliveredTimestamp: int = Field(alias="serverDeliveredTimestamp")
     dataMessage: DataMessage | None = Field(default=None, alias="dataMessage")
     typingMessage: TypingMessage | None = Field(default=None, alias="typingMessage")
+    syncMessage: dict | None = Field(default=None, alias="syncMessage")
 
     class Config:
         populate_by_name = True

--- a/app/penny/database/models.py
+++ b/app/penny/database/models.py
@@ -46,6 +46,8 @@ class MessageLog(SQLModel, table=True):
     parent_id: int | None = Field(default=None, foreign_key="messagelog.id", index=True)
     parent_summary: str | None = Field(default=None)  # Summarized thread history
     signal_timestamp: int | None = Field(default=None)  # Original Signal timestamp (ms since epoch)
+    external_id: str | None = Field(default=None, index=True)  # Platform-specific message ID
+    is_reaction: bool = Field(default=False, index=True)  # True if this is a reaction message
 
 
 class UserProfile(SQLModel, table=True):

--- a/app/penny/tests/mocks/signal_server.py
+++ b/app/penny/tests/mocks/signal_server.py
@@ -80,6 +80,44 @@ class MockSignalServer:
             if not ws.closed:
                 await ws.send_json(envelope)
 
+    async def push_reaction(
+        self,
+        sender: str,
+        emoji: str,
+        target_timestamp: int,
+        target_author: str | None = None,
+    ) -> None:
+        """Push a reaction message to all connected WebSocket clients."""
+        ts = int(time.time() * 1000)
+        envelope = {
+            "envelope": {
+                "source": sender,
+                "sourceNumber": sender,
+                "sourceUuid": str(uuid.uuid4()),
+                "sourceName": "Test User",
+                "sourceDevice": 1,
+                "timestamp": ts,
+                "serverReceivedTimestamp": ts,
+                "serverDeliveredTimestamp": ts,
+                "dataMessage": {
+                    "timestamp": ts,
+                    "message": "",
+                    "reaction": {
+                        "emoji": {"value": emoji},
+                        "targetAuthor": target_author or "+15551234567",
+                        "targetAuthorNumber": target_author or "+15551234567",
+                        "targetSentTimestamp": target_timestamp,
+                        "isRemove": False,
+                    },
+                },
+            },
+            "account": "+15551234567",
+        }
+
+        for ws in self._websockets:
+            if not ws.closed:
+                await ws.send_json(envelope)
+
     async def wait_for_message(self, timeout: float = 10.0) -> dict:
         """Wait for an outgoing message to be captured."""
         start = time.time()


### PR DESCRIPTION
## Summary

Enables users to react to Penny's messages with emoji (👍, ❤️, etc.) on both Signal and Discord. Reactions are logged as lightweight message entries that keep conversation threads alive for future followup, without triggering an immediate response from Penny.

Closes #11

## Changes

**Database schema:**
- Added `is_reaction` boolean field to `MessageLog` (default: False)
- Added `external_id` string field to `MessageLog` for platform-specific message IDs
- Added `Database.find_message_by_external_id()` method
- Added `Database.set_external_id()` method

**Channel integration:**
- Updated `MessageChannel.send_response()` to store external_id on sent messages
- Added `_handle_reaction()` method to base channel for reaction processing
- Updated `IncomingMessage` model with `is_reaction` and `reacted_to_external_id` fields
- Modified `handle_message()` to route reactions to special handler

**Signal support:**
- Added `Reaction`, `ReactionEmoji` models to parse Signal reaction messages
- Updated `DataMessage` to include optional `reaction` field
- Updated `SignalChannel.extract_message()` to detect and handle reactions
- Signal timestamp used as external_id for message lookup

**Discord support:**
- Added `on_reaction_add` event handler to `DiscordChannel`
- Enabled `reactions` intent for Discord bot
- Updated `send_message()` to return Discord message ID as external_id
- Discord message ID used as external_id for message lookup

**Tests:**
- Added `test_signal_reaction_message` integration test
- Added `MockSignalServer.push_reaction()` method

## Test Plan

- ✅ All existing tests pass
- ✅ New test verifies reaction logging and thread lifecycle
- ✅ Verified reactions don't trigger immediate responses
- ✅ Verified reacted messages are no longer conversation leaves
- ✅ Format, lint, and typecheck all pass

## Notes

This is Phase 1 (MVP) of the reaction feature as specified in the issue. Future phases can add:
- Response style adaptation based on reaction patterns
- FollowupAgent prioritization of positively-reacted threads
- Training data export for model fine-tuning

The implementation treats reactions as special incoming messages with `is_reaction=True`, which keeps them in the thread chain without polluting conversation context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)