### PR TITLE
Fix reaction parsing to handle Signal's actual format

### DIFF
--- a/app/penny/channels/signal/channel.py
+++ b/app/penny/channels/signal/channel.py
@@ -315,20 +315,27 @@ class SignalChannel(MessageChannel):
                 logger.debug("Ignoring reaction removal from %s", sender)
                 return None
 
+            # Handle both string and ReactionEmoji object formats
+            emoji = reaction.emoji if isinstance(reaction.emoji, str) else reaction.emoji.value
+
             logger.info(
                 "Extracted reaction - sender: %s, emoji: %s, target: %s",
                 sender,
-                reaction.emoji.value,
+                emoji,
                 reaction.targetSentTimestamp,
             )
             return IncomingMessage(
                 sender=sender,
-                content=reaction.emoji.value,
+                content=emoji,
                 is_reaction=True,
                 reacted_to_external_id=str(reaction.targetSentTimestamp),
             )
 
         # Regular text message
+        if envelope.envelope.dataMessage.message is None:
+            logger.debug("Ignoring message with no text content from %s", sender)
+            return None
+
         content = envelope.envelope.dataMessage.message.strip()
 
         logger.info("Extracted - sender: %s, content: '%s'", sender, content)

--- a/app/penny/channels/signal/models.py
+++ b/app/penny/channels/signal/models.py
@@ -34,7 +34,7 @@ class ReactionEmoji(BaseModel):
 class Reaction(BaseModel):
     """Reaction message from Signal."""
 
-    emoji: ReactionEmoji
+    emoji: str | ReactionEmoji
     targetAuthor: str = Field(alias="targetAuthor")
     targetAuthorNumber: str = Field(alias="targetAuthorNumber")
     targetSentTimestamp: int = Field(alias="targetSentTimestamp")
@@ -48,7 +48,7 @@ class DataMessage(BaseModel):
     """Data message from Signal."""
 
     timestamp: int
-    message: str = ""  # Empty for reactions
+    message: str | None = None  # None for reactions
     expiresInSeconds: int = Field(default=0, alias="expiresInSeconds")
     isExpirationUpdate: bool = Field(default=False, alias="isExpirationUpdate")
     viewOnce: bool = Field(default=False, alias="viewOnce")

--- a/app/penny/tests/integration/test_message_flow.py
+++ b/app/penny/tests/integration/test_message_flow.py
@@ -317,3 +317,90 @@ async def test_signal_reaction_message(
         # Verify no response was sent to the reaction
         # (only the initial response should exist)
         assert len(signal_server.outgoing_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_signal_reaction_raw_format(
+    signal_server, mock_ollama, _mock_search, make_config, running_penny
+):
+    """
+    Test Signal reaction handling with the raw format that Signal actually sends.
+
+    This tests the bug fix for issue #34 where Signal sends:
+    - message: None (not an empty string)
+    - emoji: "👍" (plain string, not {"value": "👍"} object)
+    """
+    config = make_config()
+    mock_ollama.set_default_flow(
+        search_query="test query",
+        final_response="test response 🌟",
+    )
+
+    async with running_penny(config) as penny:
+        # Send initial message
+        await signal_server.push_message(sender=TEST_SENDER, content="test message")
+        await signal_server.wait_for_message(timeout=10.0)
+
+        # Get the outgoing message's signal timestamp
+        with penny.db.get_session() as session:
+            outgoing = session.exec(
+                select(MessageLog).where(MessageLog.direction == "outgoing")
+            ).first()
+            assert outgoing is not None
+            message_id = outgoing.id
+            external_id = outgoing.external_id
+
+        # Send a reaction using the raw format that Signal actually sends
+        # (not the mock format with {"value": emoji})
+        import json
+        import time
+
+        ts = int(time.time() * 1000)
+        raw_envelope = {
+            "envelope": {
+                "source": TEST_SENDER,
+                "sourceNumber": TEST_SENDER,
+                "sourceUuid": "test-uuid-123",
+                "sourceName": "Test User",
+                "sourceDevice": 1,
+                "timestamp": ts,
+                "serverReceivedTimestamp": ts,
+                "serverDeliveredTimestamp": ts,
+                "dataMessage": {
+                    "timestamp": ts,
+                    "message": None,  # KEY: None, not empty string
+                    "reaction": {
+                        "emoji": "👍",  # KEY: Plain string, not {"value": "👍"}
+                        "targetAuthor": config.signal_number,
+                        "targetAuthorNumber": config.signal_number,
+                        "targetSentTimestamp": int(external_id),
+                        "isRemove": False,
+                    },
+                },
+            },
+            "account": config.signal_number,
+        }
+
+        # Push the raw envelope to all connected websockets
+        for ws in signal_server._websockets:
+            if not ws.closed:
+                await ws.send_str(json.dumps(raw_envelope))
+
+        # Wait a bit for processing
+        await asyncio.sleep(0.5)
+
+        # Verify reaction was logged
+        with penny.db.get_session() as session:
+            reactions = list(
+                session.exec(
+                    select(MessageLog).where(
+                        MessageLog.is_reaction == True,  # noqa: E712
+                        MessageLog.sender == TEST_SENDER,
+                    )
+                ).all()
+            )
+        assert len(reactions) == 1, "Reaction should be logged"
+        reaction = reactions[0]
+        assert reaction.content == "👍"
+        assert reaction.parent_id == message_id
+        assert reaction.is_reaction is True


### PR DESCRIPTION
## Summary

Fixed Pydantic validation errors that occurred when users reacted to messages in Signal. Signal sends reactions with `message: None` and `emoji: "👍"` (plain string), but the Pydantic models expected `message: str` and `emoji: ReactionEmoji` (object).

Closes #34

## Changes

**app/penny/channels/signal/models.py:**
- Made `DataMessage.message` optional (`str | None = None`) to handle reactions with no text content
- Made `Reaction.emoji` accept both formats (`str | ReactionEmoji`) to handle both plain strings and objects

**app/penny/channels/signal/channel.py:**
- Added type handling for `reaction.emoji` to support both string and object formats using ternary operator
- Added null check for `message` field before calling `.strip()` to prevent AttributeError

**app/penny/tests/integration/test_message_flow.py:**
- Added `test_signal_reaction_raw_format` to test the actual Signal format that was causing the bug
- Test sends raw envelope with `message: None` and `emoji: "👍"` (string) to verify parsing works correctly

## Test Plan

- All existing tests pass (7/7)
- New test specifically verifies the raw Signal format that was failing
- `make check` passes (format, lint, typecheck, tests)
- Verified reaction is correctly logged to database with `is_reaction=True`

## Notes

This was a straightforward Pydantic schema fix. The reaction functionality from #11 was already implemented correctly - we just needed to make the models match Signal's actual data format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)