### PR TITLE
feat: add log rotation and reorganize data directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,17 +15,17 @@ OLLAMA_BACKGROUND_MODEL="nemotron-3-nano:30b"  # Slower/smarter model for backgr
 PERPLEXITY_API_KEY="pplx-your-api-key-here"
 
 # Database
-DB_PATH="/penny/data/penny.db"
+DB_PATH="/penny/data/penny/penny.db"
 
 # Logging
 LOG_LEVEL="INFO"
-# LOG_FILE="/penny/data/penny.log"  # Optional: Log to file in addition to console
+# LOG_FILE="/penny/data/penny/logs/penny.log"  # Optional: Log to file in addition to console
 
 # Agent Team (pm/worker containers — leave blank to disable)
 # Run `claude setup-token` to get a long-lived OAuth token (uses Max plan)
 CLAUDE_CODE_OAUTH_TOKEN=
 GITHUB_APP_ID=
-GITHUB_APP_PRIVATE_KEY_PATH="data/github-app.pem"
+GITHUB_APP_PRIVATE_KEY_PATH="data/private/github-app.pem"
 GITHUB_APP_INSTALLATION_ID=
 
 # Agent Behavior (Optional - these are the defaults)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Penny also has an autonomous development team (`penny-team/`) — Claude CLI age
 
 ## Environment Notes
 
-- **Logs**: Runtime logs are written to `data/penny.log`; agent logs are in `data/logs/` (not docker compose logs)
+- **Logs**: Runtime logs are written to `data/penny/logs/penny.log`; agent logs are in `data/penny-team/logs/` (not docker compose logs)
 
 ## Git Workflow
 
@@ -64,6 +64,14 @@ docs/                           — Design documents
   knowledge-system-plan.md      — Knowledge System v2 design
   knowledge-system-flows.md     — Knowledge System v2 sequence diagrams
 data/                           — Runtime data (gitignored)
+  penny/                        — Penny runtime data
+    penny.db                    — Production database
+    backups/                    — DB backups (max 5)
+    logs/                       — Penny runtime logs (penny.log)
+  penny-team/                   — Agent team runtime
+    logs/                       — Agent logs + prompts
+    state/                      — Agent state files
+  private/                      — Credentials (not in repo)
 ```
 
 ## Running
@@ -139,7 +147,9 @@ GitHub Actions runs `make check` (format, lint, typecheck, tests) on every push 
 **Logging**:
 - `LOG_LEVEL`: DEBUG, INFO, WARNING, ERROR (default: INFO)
 - `LOG_FILE`: Optional path to log file
-- `DB_PATH`: SQLite database location (default: /penny/data/penny.db)
+- `LOG_MAX_BYTES`: Maximum log file size before rotation (default: 10485760 / 10 MB)
+- `LOG_BACKUP_COUNT`: Number of rotated backup files to keep (default: 5)
+- `DB_PATH`: SQLite database location (default: /penny/data/penny/penny.db)
 
 ## Testing Philosophy
 

--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ OLLAMA_BACKGROUND_MODEL="gpt-oss:20b"    # Smarter model for background tasks (d
 PERPLEXITY_API_KEY="your-api-key"
 
 # Database & Logging
-DB_PATH="/penny/data/penny.db"
+DB_PATH="/penny/data/penny/penny.db"
 LOG_LEVEL="INFO"
-# LOG_FILE="/penny/data/penny.log"  # Optional
+# LOG_FILE="/penny/data/penny/logs/penny.log"  # Optional
 
 # Agent behavior (optional, defaults shown)
 MESSAGE_MAX_STEPS=5
@@ -298,7 +298,7 @@ Penny auto-detects which channel to use based on configured credentials:
 **Logging:**
 - `LOG_LEVEL`: DEBUG, INFO, WARNING, ERROR (default: INFO)
 - `LOG_FILE`: Optional path to log file
-- `DB_PATH`: SQLite database location (default: /penny/data/penny.db)
+- `DB_PATH`: SQLite database location (default: /penny/data/penny/penny.db)
 
 </details>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
       - SIGNAL_API_URL=http://signal-api:8080
-      - LOG_FILE=/penny/data/penny.log
+      - LOG_FILE=/penny/data/penny/logs/penny.log
       - SNAPSHOT=${SNAPSHOT:-0}
 
   pm:

--- a/penny-team/Dockerfile
+++ b/penny-team/Dockerfile
@@ -39,7 +39,8 @@ ENV PYTHONPATH=/shared:/repo/penny-team
 
 # Snapshot the entire repo into the image (build context is project root)
 COPY . /repo
-RUN mkdir -p /repo/data
+RUN mkdir -p /repo/data/penny-team/state /repo/data/penny-team/logs \
+    /repo/data/penny/logs /repo/data/penny/backups /repo/data/private
 
 # Install Python deps from baked-in source
 RUN cd /repo/penny && uv pip install --system . --group dev --quiet

--- a/penny-team/penny_team/base.py
+++ b/penny-team/penny_team/base.py
@@ -21,8 +21,8 @@ from penny_team.constants import TeamConstants
 
 AGENTS_DIR = Path(__file__).parent
 PROJECT_ROOT = AGENTS_DIR.parent.parent
-DATA_DIR = PROJECT_ROOT / "data" / "penny-team"
-LOG_DIR = PROJECT_ROOT / "data" / "logs"
+DATA_DIR = PROJECT_ROOT / TeamConstants.TEAM_STATE_DIR
+LOG_DIR = PROJECT_ROOT / TeamConstants.TEAM_LOG_DIR
 
 logger = logging.getLogger(__name__)
 

--- a/penny-team/penny_team/constants.py
+++ b/penny-team/penny_team/constants.py
@@ -167,5 +167,8 @@ class TeamConstants:
     ENV_OLLAMA_URL = "OLLAMA_API_URL"
     ENV_OLLAMA_MODEL = "OLLAMA_BACKGROUND_MODEL"
 
-    # Penny database path (relative to project root)
-    PENNY_DB_RELATIVE_PATH = "data/penny.db"
+    # Data directory layout (relative to project root)
+    PENNY_DB_RELATIVE_PATH = "data/penny/penny.db"
+    PENNY_LOG_RELATIVE_PATH = "data/penny/logs/penny.log"
+    TEAM_STATE_DIR = "data/penny-team/state"
+    TEAM_LOG_DIR = "data/penny-team/logs"

--- a/penny-team/penny_team/monitor.py
+++ b/penny-team/penny_team/monitor.py
@@ -152,7 +152,7 @@ class MonitorAgent(Agent):
         if log_path is not None:
             self.log_path = Path(log_path)
         else:
-            self.log_path = PROJECT_ROOT / "data" / "penny.log"
+            self.log_path = PROJECT_ROOT / TeamConstants.PENNY_LOG_RELATIVE_PATH
 
     def _load_offset(self) -> int:
         """Load saved byte offset from state file."""

--- a/penny-team/tests/test_agent_shared.py
+++ b/penny-team/tests/test_agent_shared.py
@@ -299,7 +299,7 @@ class TestBuildCommand:
 
 class TestPromptLogging:
     def test_prompt_written_to_log_file(self, tmp_path, capture_popen, monkeypatch):
-        """run() writes the full prompt to data/logs/{name}.prompt.md."""
+        """run() writes the full prompt to penny-team/logs/{name}.prompt.md."""
         log_dir = tmp_path / "data" / "logs"
         monkeypatch.setattr("penny_team.base.LOG_DIR", log_dir)
 

--- a/penny/entrypoint.sh
+++ b/penny/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-PROD_DB="/penny/data/penny.db"
+PROD_DB="/penny/data/penny/penny.db"
 
 # Create production backup only when SNAPSHOT=1 (set by make up / make prod)
 if [ "${SNAPSHOT:-0}" = "1" ] && [ -f "$PROD_DB" ]; then
-    BACKUP_DIR="/penny/data/backups"
+    BACKUP_DIR="/penny/data/penny/backups"
     mkdir -p "$BACKUP_DIR"
     TIMESTAMP=$(date +%Y%m%d_%H%M%S)
     BACKUP_FILE="$BACKUP_DIR/penny.db.$TIMESTAMP"
@@ -18,7 +18,7 @@ fi
 
 # Always create test database snapshot (needed by pytest)
 if [ -f "$PROD_DB" ]; then
-    TEST_DB="/penny/data/penny-test.db"
+    TEST_DB="/penny/data/penny/penny-test.db"
     echo "Creating test database snapshot: $TEST_DB"
     cp "$PROD_DB" "$TEST_DB"
 fi

--- a/penny/penny/constants.py
+++ b/penny/penny/constants.py
@@ -75,7 +75,7 @@ class PennyConstants:
     EMAIL_BODY_MAX_LENGTH = 4000
 
     # Test mode constants
-    TEST_DB_PATH = Path("data/penny-test.db")
+    TEST_DB_PATH = Path("data/penny/penny-test.db")
 
     # GitHub constants
     GITHUB_REPO_OWNER = "jaredlockhart"

--- a/penny/penny/database/migrate.py
+++ b/penny/penny/database/migrate.py
@@ -188,10 +188,10 @@ if __name__ == "__main__":
 
     if "--test" in args:
         args.remove("--test")
-        db_path = args[0] if args else "/penny/data/penny.db"
+        db_path = args[0] if args else "/penny/data/penny/penny.db"
         success = migrate_test(db_path)
         sys.exit(0 if success else 1)
 
-    db_path = args[0] if args else "/penny/data/penny.db"
+    db_path = args[0] if args else "/penny/data/penny/penny.db"
     count = migrate(db_path)
     logger.info("Done. %d migration(s) applied.", count)

--- a/penny/penny/penny.py
+++ b/penny/penny/penny.py
@@ -355,7 +355,7 @@ class Penny:
 async def main() -> None:
     """Main entry point."""
     config = Config.load()
-    setup_logging(config.log_level, config.log_file)
+    setup_logging(config.log_level, config.log_file, config.log_max_bytes, config.log_backup_count)
 
     logger.info("Starting Penny with config:")
     logger.info("  channel_type: %s", config.channel_type)


### PR DESCRIPTION
## Summary
- Add `RotatingFileHandler` for penny and penny-team logs (10 MB max, 5 backups), configurable via `LOG_MAX_BYTES` and `LOG_BACKUP_COUNT` env vars
- Add manual size-based rotation for penny-team per-agent log files (`save_agent_log`)
- Reorganize `data/` into namespaced subdirectories: `data/penny/` (db, backups, logs), `data/penny-team/` (logs, state), `data/private/` (credentials)
- Centralize all penny-team data paths as constants in `TeamConstants`

Closes #374

## Test plan
- [x] `make check` passes (268 penny + 137 penny-team tests)
- [ ] Deploy: move existing files to new locations per migration steps below
- [ ] Verify `data/penny/penny.db` is written to
- [ ] Verify `data/penny/logs/penny.log` is written to and rotates
- [ ] Verify `data/penny-team/logs/orchestrator.log` is written to
- [ ] Verify `data/penny-team/state/*.state.json` files are created/updated

### Production migration
```bash
make kill
mkdir -p data/penny/logs data/penny/backups data/penny-team/state data/penny-team/logs data/private
mv data/penny.db data/penny/
mv data/penny.log* data/penny/logs/
mv data/backups/* data/penny/backups/ && rmdir data/backups
mv data/logs/* data/penny-team/logs/ && rmdir data/logs
mv data/penny-team/*.state.json data/penny-team/state/
mv data/github-app.pem data/private/
# Update .env: DB_PATH, LOG_FILE, GITHUB_APP_PRIVATE_KEY_PATH
make up
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)