### PR TITLE
docs: link TODO.md to docs/ directory

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # Penny Feature TODO
 
-This document tracks potential new features and enhancements for Penny.
+This document tracks potential new features and enhancements for Penny. See [`docs/`](docs/) for in-depth design documents.
 
 ## New Agent Types
 


### PR DESCRIPTION
## Summary
- Small connectivity test PR
- Adds a one-line pointer from `TODO.md` to the `docs/` directory so readers can find existing design documents

## Test plan
- [ ] Confirm CI (`make check`) passes — change is docs-only

https://claude.ai/code/session_01Wy5FR1cGSyV2XYQX2seggq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wy5FR1cGSyV2XYQX2seggq)_