### PR TITLE
penny-client chat UI/UX improvements + paginated message loading

### DIFF
--- a/penny-client/PennyClient/Service/DatabaseService.swift
+++ b/penny-client/PennyClient/Service/DatabaseService.swift
@@ -78,6 +78,45 @@ extension DatabaseService {
         }
     }
 
+    @MainActor
+    func loadMessagePage(_ request: MessagePageRequest) -> MessagePage {
+        setup()
+
+        do {
+            let page = try MessageModel.loadPage(db: db, request: request)
+            return MessagePage(
+                messages: page.models.map(ChatMessage.init(model:)),
+                nextCursor: page.nextCursor,
+                hasMore: page.hasMore
+            )
+        } catch {
+            print(error)
+            return MessagePage(messages: [], nextCursor: nil, hasMore: false)
+        }
+    }
+
+    func minimumMessageID() -> Int? {
+        setup()
+
+        do {
+            return try MessageModel.minimumID(db: db)
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+
+    func containsMessage(serverID: Int) -> Bool {
+        setup()
+
+        do {
+            return try MessageModel.contains(db: db, serverID: serverID)
+        } catch {
+            print(error)
+            return false
+        }
+    }
+
     func save(message: MessageModel) {
         setup()
 
@@ -162,19 +201,69 @@ struct MessageModel: Codable, Identifiable, Hashable {
     fileprivate static func load(db: Connection) throws -> [MessageModel] {
         var result = [MessageModel]()
         for entry in try db.prepare(table().order(createdAtExp.asc)) {
-            result.append(
-                MessageModel(
-                    id: entry[idExp],
-                    serverID: entry[serverIDExp],
-                    createdAt: entry[createdAtExp],
-                    content: entry[contentExp],
-                    sourceHint: entry[sourceHintExp],
-                    imageAttachmentDataURLs: decodedImageAttachmentDataURLs(entry[imageAttachmentDataURLsExp]),
-                    isOutgoing: entry[isOutgoingExp]
-                )
-            )
+            result.append(message(from: entry))
         }
         return result
+    }
+
+    @MainActor
+    fileprivate static func loadPage(db: Connection, request: MessagePageRequest) throws -> (models: [MessageModel], nextCursor: MessagePageCursor?, hasMore: Bool) {
+        let limit = max(1, request.limit)
+        var query = filteredTable(for: request.filter)
+
+        if let before = request.before {
+            query = query.filter(createdAtExp < before.createdAt || (createdAtExp == before.createdAt && idExp < before.id))
+        }
+
+        query = query
+            .order(createdAtExp.desc, idExp.desc)
+            .limit(limit + 1)
+
+        let fetched = try db.prepare(query).map(message(from:))
+        let hasMore = fetched.count > limit
+        let models = fetched.prefix(limit).reversed()
+        let nextCursor = models.first.map { MessagePageCursor(createdAt: $0.createdAt, id: $0.id) }
+        return (Array(models), nextCursor, hasMore)
+    }
+
+    fileprivate static func minimumID(db: Connection) throws -> Int? {
+        for entry in try db.prepare(table().select(idExp).order(idExp.asc).limit(1)) {
+            return entry[idExp]
+        }
+        return nil
+    }
+
+    fileprivate static func contains(db: Connection, serverID: Int) throws -> Bool {
+        try db.scalar(table().filter(serverIDExp == serverID).count) > 0
+    }
+
+    private static func filteredTable(for filter: MessagePageFilter) -> Table {
+        switch filter {
+        case .all:
+            return table()
+        case .penny:
+            return table().filter(sourceHintExp == "Penny" || sourceHintExp == "Startup" || sourceHintExp == "Test Push")
+        case .schedule:
+            return table().filter(sourceHintExp == "Schedule")
+        case .chat:
+            return table().filter(isOutgoingExp || sourceHintExp == "Chat")
+        case .notifier:
+            return table().filter(sourceHintExp == "Notifier")
+        case .collector:
+            return table().filter(sourceHintExp.like("Collector: %"))
+        }
+    }
+
+    private static func message(from entry: Row) -> MessageModel {
+        MessageModel(
+            id: entry[idExp],
+            serverID: entry[serverIDExp],
+            createdAt: entry[createdAtExp],
+            content: entry[contentExp],
+            sourceHint: entry[sourceHintExp],
+            imageAttachmentDataURLs: decodedImageAttachmentDataURLs(entry[imageAttachmentDataURLsExp]),
+            isOutgoing: entry[isOutgoingExp]
+        )
     }
 
     fileprivate static func encodedImageAttachmentDataURLs(_ dataURLs: [String]) -> String {

--- a/penny-client/PennyClient/Service/PennyService.swift
+++ b/penny-client/PennyClient/Service/PennyService.swift
@@ -4,6 +4,80 @@ import SwiftUI
 import UIKit
 import UserNotifications
 
+struct MessagePageCursor: Equatable, Sendable {
+    let createdAt: Date
+    let id: Int
+}
+
+extension MessagePageCursor: CustomStringConvertible {
+    var description: String {
+        "createdAt=\(createdAt.ISO8601Format()), id=\(id)"
+    }
+}
+
+struct MessagePageRequest: Sendable {
+    let limit: Int
+    let before: MessagePageCursor?
+    let filter: MessagePageFilter
+
+    init(limit: Int = 30, before: MessagePageCursor? = nil, filter: MessagePageFilter = .all) {
+        self.limit = limit
+        self.before = before
+        self.filter = filter
+    }
+}
+
+struct MessagePage {
+    let messages: [ChatMessage]
+    let nextCursor: MessagePageCursor?
+    let hasMore: Bool
+}
+
+enum MessagePageFilter: Equatable, Sendable {
+    case all
+    case penny
+    case schedule
+    case chat
+    case notifier
+    case collector
+
+    private static let collectorPrefix = "Collector: "
+
+    var debugDescription: String {
+        switch self {
+        case .all:
+            return "all"
+        case .penny:
+            return "penny"
+        case .schedule:
+            return "schedule"
+        case .chat:
+            return "chat"
+        case .notifier:
+            return "notifier"
+        case .collector:
+            return "collector"
+        }
+    }
+
+    func includes(_ message: ChatMessage) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .penny:
+            return ["Penny", "Startup", "Test Push"].contains(message.sourceHint)
+        case .schedule:
+            return message.sourceHint == "Schedule"
+        case .chat:
+            return message.isOutgoing || message.sourceHint == "Chat"
+        case .notifier:
+            return message.sourceHint == "Notifier"
+        case .collector:
+            return message.sourceHint?.hasPrefix(Self.collectorPrefix) == true
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class PennyService {
@@ -15,6 +89,10 @@ final class PennyService {
     private let prefs: Prefs
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+
+    @ObservationIgnored private var liveMessages: Binding<[ChatMessage]>?
+    @ObservationIgnored private var liveHasNewMessages: Binding<Bool>?
+    @ObservationIgnored private var liveMessageFilter: MessagePageFilter = .all
 
     var messages: [ChatMessage] = []
     var pendingCount = 0
@@ -35,40 +113,39 @@ final class PennyService {
     var domainPermissions: [DomainPermissionEntry] = []
     var permissionPrompt: PermissionPrompt?
 
-    private let messageLimit = 3
+    private let pendingMessagePullLimit = 3
 
     init() {
         self.databaseService = .shared
         self.prefs = .shared
         self.webSocketClient = WebSocketClient()
-        loadSavedMessages()
+        prepareMessageStore()
     }
 
     init(databaseService: DatabaseService) {
         self.databaseService = databaseService
         self.prefs = .shared
         self.webSocketClient = WebSocketClient()
-        loadSavedMessages()
+        prepareMessageStore()
     }
 
     init(databaseService: DatabaseService, prefs: Prefs) {
         self.databaseService = databaseService
         self.prefs = prefs
         self.webSocketClient = WebSocketClient()
-        loadSavedMessages()
+        prepareMessageStore()
     }
 
     init(databaseService: DatabaseService, prefs: Prefs, webSocketClient: any WebSocketTransport) {
         self.databaseService = databaseService
         self.prefs = prefs
         self.webSocketClient = webSocketClient
-        loadSavedMessages()
+        prepareMessageStore()
     }
 
-    private func loadSavedMessages() {
+    private func prepareMessageStore() {
         databaseService.setup()
-        messages = databaseService.loadMessages().map(ChatMessage.init(model:))
-        localMessageID = min(-1, (messages.map(\.id).min() ?? 0) - 1)
+        localMessageID = min(-1, (databaseService.minimumMessageID() ?? 0) - 1)
     }
 
     var canSend: Bool {
@@ -115,26 +192,66 @@ final class PennyService {
 
         startBackgroundTasks()
         sendRegistration()
-        send(.pullMessages(limit: messageLimit))
+        send(.pullMessages(limit: pendingMessagePullLimit))
     }
 
     func reconnect() {
-        disconnect()
+        disconnect(clearLiveBindings: false)
         Task { await connect() }
     }
 
     func disconnect() {
+        disconnect(clearLiveBindings: true)
+    }
+
+    private func disconnect(clearLiveBindings: Bool) {
         stopBackgroundTasks()
+        if clearLiveBindings {
+            unbindLiveMessages()
+        }
         webSocketClient.disconnect()
         isConnected = false
         isRegistered = false
         isTyping = false
     }
 
+    func requestMessagePage(_ request: MessagePageRequest) async -> MessagePage {
+        debugLogFrame(
+            "message page requested " +
+            "(limit=\(request.limit), before=\(request.before?.description ?? "nil"), filter=\(request.filter.debugDescription))"
+        )
+        let page = databaseService.loadMessagePage(request)
+        debugLogFrame(
+            "message page returned " +
+            "(count=\(page.messages.count), hasMore=\(page.hasMore), nextCursor=\(page.nextCursor?.description ?? "nil"))"
+        )
+        return page
+    }
+
+    func bindLiveMessages(
+        _ messages: Binding<[ChatMessage]>,
+        hasNewMessages: Binding<Bool>,
+        filter: MessagePageFilter
+    ) {
+        liveMessages = messages
+        liveHasNewMessages = hasNewMessages
+        liveMessageFilter = filter
+    }
+
+    func updateLiveMessageFilter(_ filter: MessagePageFilter) {
+        liveMessageFilter = filter
+    }
+
+    func unbindLiveMessages() {
+        liveMessages = nil
+        liveHasNewMessages = nil
+    }
+
     func sendMessage(_ content: String) {
         let message = ChatMessage.local(id: nextLocalMessageID(), content: content)
         messages.append(message)
         databaseService.save(message: MessageModel(message: message))
+        publishLiveMessages([message])
         send(.message(content: content))
     }
 
@@ -366,11 +483,11 @@ final class PennyService {
             isConnected = true
             isRegistered = true
             pendingCount = payload.pendingCount
-            send(.pullMessages(limit: messageLimit))
+            send(.pullMessages(limit: pendingMessagePullLimit))
         case .outboxChanged(let payload):
             pendingCount = payload.pendingCount
             if payload.pendingCount > 0 {
-                send(.pullMessages(limit: messageLimit))
+                send(.pullMessages(limit: pendingMessagePullLimit))
             }
         case .messages(let payload):
             receive(payload.messages)
@@ -451,15 +568,15 @@ final class PennyService {
             return
         }
 
-        let existingIDs = Set(messages.compactMap(\.serverID))
         let newMessages = incomingMessages
-            .filter { !existingIDs.contains($0.id) }
+            .filter { !databaseService.containsMessage(serverID: $0.id) }
             .map(ChatMessage.remote)
 
         if !newMessages.isEmpty {
+            newMessages.forEach { databaseService.save(message: MessageModel(message: $0)) }
             messages.append(contentsOf: newMessages)
             messages.sort { $0.createdAt < $1.createdAt }
-            newMessages.forEach { databaseService.save(message: MessageModel(message: $0)) }
+            publishLiveMessages(newMessages)
         }
 
         send(.ackMessages(ids: incomingIDs))
@@ -467,7 +584,20 @@ final class PennyService {
         clearAppBadge()
 
         if pendingCount > 0 {
-            send(.pullMessages(limit: messageLimit))
+            send(.pullMessages(limit: pendingMessagePullLimit))
+        }
+    }
+
+    private func publishLiveMessages(_ newMessages: [ChatMessage]) {
+        guard !newMessages.isEmpty else { return }
+
+        let visibleMessages = newMessages.filter { liveMessageFilter.includes($0) }
+        if !visibleMessages.isEmpty {
+            liveMessages?.wrappedValue.append(contentsOf: visibleMessages)
+        }
+
+        if visibleMessages.count != newMessages.count {
+            liveHasNewMessages?.wrappedValue = true
         }
     }
 

--- a/penny-client/PennyClient/Views/ChatMessageView.swift
+++ b/penny-client/PennyClient/Views/ChatMessageView.swift
@@ -3,7 +3,15 @@ import SwiftUI
 struct ChatMessageView: View {
     let message: ChatMessage
     let layout: MessageView.MessageLayout
-    let isSelected: Bool
+    let showsSourceHintInline: Bool
+    let fillsMessageRowWidth: Bool
+
+    init(message: ChatMessage, layout: MessageView.MessageLayout, showsSourceHintInline: Bool = true, fillsMessageRowWidth: Bool = false) {
+        self.message = message
+        self.layout = layout
+        self.showsSourceHintInline = showsSourceHintInline
+        self.fillsMessageRowWidth = fillsMessageRowWidth
+    }
 
     private var markdownTextBlocks: [AttributedString] {
         message.content
@@ -50,19 +58,12 @@ struct ChatMessageView: View {
     }
 
     @ViewBuilder
-    private func selectionBorder(cornerRadius: CGFloat) -> some View {
-        if isSelected {
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .stroke(Color(.systemGray3), lineWidth: 2)
-        }
-    }
-
-    @ViewBuilder
     private var messageBubble: some View {
         if message.isOutgoing {
             Text(message.content)
                 .font(.body)
                 .foregroundStyle(.white)
+                .frame(maxWidth: fillsMessageRowWidth ? .infinity : nil, alignment: .leading)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 9)
                 .background(Color.accentColor, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
@@ -83,17 +84,11 @@ struct ChatMessageView: View {
                 }
             }
             .foregroundStyle(.primary)
+            .frame(maxWidth: fillsMessageRowWidth ? .infinity : nil, alignment: .leading)
             .padding(.horizontal, 12)
             .padding(.vertical, 9)
             .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
         }
-    }
-
-    private var selectedMessageBubble: some View {
-        messageBubble
-            .overlay {
-                selectionBorder(cornerRadius: 16)
-            }
     }
 
     var body: some View {
@@ -109,25 +104,25 @@ struct ChatMessageView: View {
 
     private var messageRow: some View {
         HStack {
-            if message.isOutgoing {
+            if message.isOutgoing && !fillsMessageRowWidth {
                 Spacer(minLength: 48)
             }
 
-            VStack(alignment: message.isOutgoing ? .trailing : .leading, spacing: 5) {
-                if let sourceHint = message.sourceHint, !sourceHint.isEmpty {
+            VStack(alignment: message.isOutgoing && !fillsMessageRowWidth ? .trailing : .leading, spacing: 5) {
+                if showsSourceHintInline, let sourceHint = message.sourceHint, !sourceHint.isEmpty {
                     Text(sourceHint)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(.secondary)
                 }
 
-                selectedMessageBubble
+                messageBubble
 
                 Text(message.displayTime)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
 
-            if !message.isOutgoing {
+            if !message.isOutgoing && !fillsMessageRowWidth {
                 Spacer(minLength: 48)
             }
         }
@@ -159,9 +154,6 @@ struct ChatMessageView: View {
         .padding(8)
         .frame(maxWidth: .infinity, minHeight: 192, alignment: .topLeading)
         .background(compactCardBackground, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay {
-            selectionBorder(cornerRadius: 8)
-        }
     }
 
     private var mediaCard: some View {
@@ -192,9 +184,6 @@ struct ChatMessageView: View {
         }
         .padding(message.isOutgoing ? 3 : 0)
         .background(message.isOutgoing ? Color.accentColor : Color.clear, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .overlay {
-            selectionBorder(cornerRadius: message.isOutgoing ? 10 : 8)
-        }
     }
 }
 

--- a/penny-client/PennyClient/Views/ChatMessageView.swift
+++ b/penny-client/PennyClient/Views/ChatMessageView.swift
@@ -188,14 +188,14 @@ struct ChatMessageView: View {
 }
 
 extension MessageView.MessageLayout {
-    var gridColumns: [GridItem] {
+    var columnCount: Int {
         switch self {
         case .message:
-            return [GridItem(.flexible(), spacing: 12)]
+            return 1
         case .compact:
-            return Array(repeating: GridItem(.flexible(), spacing: 8), count: 2)
+            return 2
         case .media:
-            return Array(repeating: GridItem(.flexible(), spacing: 6), count: 3)
+            return 3
         }
     }
 

--- a/penny-client/PennyClient/Views/MessageView+ViewModel.swift
+++ b/penny-client/PennyClient/Views/MessageView+ViewModel.swift
@@ -3,16 +3,6 @@ import SwiftUI
 import UIKit
 
 extension MessageView {
-    fileprivate struct MessageFilterInput: Sendable {
-        let sourceHint: String?
-        let isOutgoing: Bool
-
-        init(message: ChatMessage) {
-            sourceHint = message.sourceHint
-            isOutgoing = message.isOutgoing
-        }
-    }
-
     enum MessageLayout: Int, CaseIterable, Identifiable, Sendable {
         case message = 1
         case compact = 2
@@ -45,8 +35,6 @@ extension MessageView {
         case collector
 
         var id: Self { self }
-
-        nonisolated private static let collectorPrefix = "Collector: "
 
         var title: String {
             switch self {
@@ -82,33 +70,20 @@ extension MessageView {
             }
         }
 
-        nonisolated private var sourceHint: String? {
-            switch self {
-            case .all, .collector:
-                return nil
-            case .penny:
-                return "Penny"
-            case .schedule:
-                return "Schedule"
-            case .chat:
-                return "Chat"
-            case .notifier:
-                return "Notifier"
-            }
-        }
-
-        nonisolated fileprivate func includes(_ input: MessageFilterInput) -> Bool {
+        var pageFilter: MessagePageFilter {
             switch self {
             case .all:
-                return true
+                return .all
             case .penny:
-                return ["Penny", "Startup", "Test Push"].contains(input.sourceHint)
+                return .penny
+            case .schedule:
+                return .schedule
             case .chat:
-                return input.isOutgoing || input.sourceHint == sourceHint
+                return .chat
+            case .notifier:
+                return .notifier
             case .collector:
-                return input.sourceHint?.hasPrefix(Self.collectorPrefix) == true
-            default:
-                return input.sourceHint == sourceHint
+                return .collector
             }
         }
     }
@@ -124,22 +99,40 @@ extension MessageView {
         var selectedMessageLayout: MessageLayout = .message
         var selectedMessageFilter: MessageFilter = .all {
             didSet {
+                guard selectedMessageFilter != oldValue else { return }
                 if selectedMessageFilter == .all {
                     hasHiddenNewMessages = false
                 }
-                refreshFilteredMessages()
+                client.updateLiveMessageFilter(selectedMessageFilter.pageFilter)
+                reloadMessagesForSelectedFilter()
             }
         }
-        var filteredMessages: [ChatMessage]
+        var displayedMessages: [ChatMessage] = [] {
+            didSet {
+                handleDisplayedMessagesChanged(previousMessages: oldValue)
+            }
+        }
+        var isAtBottom = true
+        var isLoadingOlderMessages = false
+        var hasMoreOlderMessages = false
+        var scrollToBottomRequest = 0
         var composerHeight: CGFloat = 64
         var keyboardHeight: CGFloat = 0
 
-        @ObservationIgnored private var filterTask: Task<Void, Never>?
+        @ObservationIgnored private let messagePageSize: Int
+        @ObservationIgnored private var nextOlderCursor: MessagePageCursor?
+        @ObservationIgnored private var pagingTask: Task<Void, Never>?
+        @ObservationIgnored private var suppressDisplayedMessageChanges = false
+        @ObservationIgnored private var hasBoundLiveMessages = false
+        @ObservationIgnored private var olderPagingEnabled = false
+        @ObservationIgnored private var messagePagingGeneration = 0
+        @ObservationIgnored private var reservedOlderMessageLoad: OlderMessageLoad?
+        @ObservationIgnored private var isRestoringOlderMessageScroll = false
 
-        init(client: PennyWebSocketClient? = nil) {
+        init(client: PennyWebSocketClient? = nil, messagePageSize: Int = 30) {
             let resolvedClient = client ?? PennyWebSocketClient()
             self.client = resolvedClient
-            filteredMessages = resolvedClient.messages
+            self.messagePageSize = max(1, messagePageSize)
         }
 
         private let keyboardComposerSpacing: CGFloat = -24
@@ -152,73 +145,129 @@ extension MessageView {
             selectedMessageFilter == .all || selectedMessageFilter == .chat
         }
 
-        func refreshFilteredMessages() {
-            let filter = selectedMessageFilter
-            let messages = client.messages
-            let inputs = messages.map(MessageFilterInput.init)
+        var canLoadOlderMessages: Bool {
+            olderPagingEnabled && hasMoreOlderMessages && !isLoadingOlderMessages && !isRestoringOlderMessageScroll
+        }
 
-            filterTask?.cancel()
-            filterTask = Task { [weak self] in
-                let matchingIndexes = await Task.detached(priority: .userInitiated) {
-                    inputs.indices.filter { index in
-                        filter.includes(inputs[index])
-                    }
-                }.value
+        func connect() async {
+            bindLiveMessagesIfNeeded()
+            await loadLatestMessages()
+            await client.connect()
+        }
 
-                guard !Task.isCancelled else { return }
-                let filteredMessages = matchingIndexes.map { messages[$0] }
-                self?.filteredMessages = filteredMessages
+        func disconnect() {
+            client.unbindLiveMessages()
+            hasBoundLiveMessages = false
+            client.disconnect()
+        }
+
+        func reconnect() {
+            bindLiveMessagesIfNeeded()
+            client.reconnect()
+        }
+
+        func loadLatestMessages() async {
+            messagePagingGeneration += 1
+            reservedOlderMessageLoad = nil
+            isRestoringOlderMessageScroll = false
+            isLoadingOlderMessages = false
+            olderPagingEnabled = false
+            let page = await client.requestMessagePage(MessagePageRequest(limit: messagePageSize, filter: selectedMessageFilter.pageFilter))
+            replaceDisplayedMessages(with: page.messages)
+            nextOlderCursor = page.nextCursor
+            hasMoreOlderMessages = page.hasMore
+            scrollToBottomRequest += 1
+        }
+
+        func reserveOlderMessageLoad() -> Int? {
+            guard canLoadOlderMessages else { return nil }
+            guard let nextOlderCursor, let anchorID = displayedMessages.first?.id else { return nil }
+            isLoadingOlderMessages = true
+            reservedOlderMessageLoad = OlderMessageLoad(
+                cursor: nextOlderCursor,
+                filter: selectedMessageFilter.pageFilter,
+                generation: messagePagingGeneration
+            )
+            return anchorID
+        }
+
+        func loadReservedOlderMessages() async -> Bool {
+            guard let reservation = reservedOlderMessageLoad else {
+                isLoadingOlderMessages = false
+                return false
             }
+            defer {
+                isLoadingOlderMessages = false
+                reservedOlderMessageLoad = nil
+            }
+
+            try? await Task.sleep(for: .milliseconds(250))
+            guard messagePagingGeneration == reservation.generation,
+                  nextOlderCursor == reservation.cursor,
+                  selectedMessageFilter.pageFilter == reservation.filter else {
+                return false
+            }
+
+            let page = await client.requestMessagePage(
+                MessagePageRequest(
+                    limit: messagePageSize,
+                    before: reservation.cursor,
+                    filter: reservation.filter
+                )
+            )
+            self.nextOlderCursor = page.nextCursor
+            hasMoreOlderMessages = page.hasMore
+
+            let existingIDs = Set(displayedMessages.map(\.id))
+            let olderMessages = page.messages.filter { !existingIDs.contains($0.id) }
+            guard !olderMessages.isEmpty else { return false }
+
+            suppressDisplayedMessageChanges = true
+            displayedMessages.insert(contentsOf: olderMessages, at: 0)
+            suppressDisplayedMessageChanges = false
+            isRestoringOlderMessageScroll = true
+            return true
+        }
+
+        func finishOlderMessageScrollRestoration() {
+            isRestoringOlderMessageScroll = false
+        }
+
+        func enableOlderPaging() {
+            olderPagingEnabled = true
+        }
+
+        func requestScrollToBottom() {
+            olderPagingEnabled = false
+            reservedOlderMessageLoad = nil
+            isRestoringOlderMessageScroll = false
+            isAtBottom = true
+            scrollToBottomRequest += 1
+        }
+
+        func updateBottomVisibility(_ isVisible: Bool) {
+            isAtBottom = isVisible
+            if isVisible && selectedMessageFilter == .all {
+                hasHiddenNewMessages = false
+            }
+        }
+
+        func waitForPaging() async {
+            await pagingTask?.value
         }
 
         func waitForFiltering() async {
-            await filterTask?.value
-        }
-
-        func handleMessagesChanged(previousMessageCount: Int) async -> Bool {
-            let messages = client.messages
-            let newMessages = messages.dropFirst(min(previousMessageCount, messages.count))
-            guard !newMessages.isEmpty else {
-                refreshFilteredMessages()
-                await waitForFiltering()
-                return true
-            }
-
-            let filter = selectedMessageFilter
-            let inputs = newMessages.map(MessageFilterInput.init)
-            let hasVisibleNewMessages = inputs.contains(where: filter.includes)
-            let hasFilteredNewMessages = inputs.contains { !filter.includes($0) }
-
-            if hasFilteredNewMessages && filter != .all {
-                hasHiddenNewMessages = true
-            }
-
-            guard hasVisibleNewMessages else { return false }
-            refreshFilteredMessages()
-            await waitForFiltering()
-            return true
+            await waitForPaging()
         }
 
         func clearFiltersAndShowNewMessages() async {
             hasHiddenNewMessages = false
             if selectedMessageFilter == .all {
-                refreshFilteredMessages()
+                await loadLatestMessages()
             } else {
                 selectedMessageFilter = .all
+                await waitForPaging()
             }
-            await waitForFiltering()
-        }
-
-        func connect() async {
-            await client.connect()
-        }
-
-        func disconnect() {
-            client.disconnect()
-        }
-
-        func reconnect() {
-            client.reconnect()
         }
 
         func sendDraft() {
@@ -226,21 +275,18 @@ extension MessageView {
             guard !trimmedMessage.isEmpty else { return }
 
             draftMessage = ""
-            client.sendMessage(trimmedMessage)
-
-            if selectedMessageFilter == .all {
-                refreshFilteredMessages()
-            } else {
+            if selectedMessageFilter != .all {
                 selectedMessageFilter = .all
             }
+            client.sendMessage(trimmedMessage)
         }
 
         func handleScenePhaseChange(_ phase: ScenePhase) {
             switch phase {
             case .active:
-                Task { await client.connect() }
+                Task { await connect() }
             case .background:
-                client.disconnect()
+                disconnect()
             case .inactive:
                 break
             @unknown default:
@@ -261,5 +307,55 @@ extension MessageView {
                 keyboardHeight = overlap
             }
         }
+
+        private func reloadMessagesForSelectedFilter() {
+            pagingTask?.cancel()
+            pagingTask = Task { [weak self] in
+                await self?.loadLatestMessages()
+            }
+        }
+
+        private func bindLiveMessagesIfNeeded() {
+            if hasBoundLiveMessages {
+                client.updateLiveMessageFilter(selectedMessageFilter.pageFilter)
+                return
+            }
+
+            client.bindLiveMessages(
+                Binding(
+                    get: { [weak self] in self?.displayedMessages ?? [] },
+                    set: { [weak self] messages in self?.displayedMessages = messages }
+                ),
+                hasNewMessages: Binding(
+                    get: { [weak self] in self?.hasHiddenNewMessages ?? false },
+                    set: { [weak self] hasNewMessages in self?.hasHiddenNewMessages = hasNewMessages }
+                ),
+                filter: selectedMessageFilter.pageFilter
+            )
+            hasBoundLiveMessages = true
+        }
+
+        private func replaceDisplayedMessages(with messages: [ChatMessage]) {
+            suppressDisplayedMessageChanges = true
+            displayedMessages = messages
+            suppressDisplayedMessageChanges = false
+        }
+
+        private func handleDisplayedMessagesChanged(previousMessages: [ChatMessage]) {
+            guard !suppressDisplayedMessageChanges else { return }
+            guard displayedMessages.count > previousMessages.count else { return }
+
+            if isAtBottom {
+                scrollToBottomRequest += 1
+            } else {
+                hasHiddenNewMessages = true
+            }
+        }
+    }
+
+    private struct OlderMessageLoad {
+        let cursor: MessagePageCursor
+        let filter: MessagePageFilter
+        let generation: Int
     }
 }

--- a/penny-client/PennyClient/Views/MessageView+ViewModel.swift
+++ b/penny-client/PennyClient/Views/MessageView+ViewModel.swift
@@ -1,6 +1,5 @@
 import Observation
 import SwiftUI
-import UIKit
 
 extension MessageView {
     enum MessageLayout: Int, CaseIterable, Identifiable, Sendable {
@@ -116,8 +115,6 @@ extension MessageView {
         var isLoadingOlderMessages = false
         var hasMoreOlderMessages = false
         var scrollToBottomRequest = 0
-        var composerHeight: CGFloat = 64
-        var keyboardHeight: CGFloat = 0
 
         @ObservationIgnored private let messagePageSize: Int
         @ObservationIgnored private var nextOlderCursor: MessagePageCursor?
@@ -133,12 +130,6 @@ extension MessageView {
             let resolvedClient = client ?? PennyWebSocketClient()
             self.client = resolvedClient
             self.messagePageSize = max(1, messagePageSize)
-        }
-
-        private let keyboardComposerSpacing: CGFloat = -24
-
-        var keyboardOffset: CGFloat {
-            keyboardHeight > 0 ? keyboardHeight + keyboardComposerSpacing : 0
         }
 
         var shouldShowTypingIndicator: Bool {
@@ -245,6 +236,12 @@ extension MessageView {
             scrollToBottomRequest += 1
         }
 
+        func prepareComposerFocus() {
+            if selectedMessageLayout != .message {
+                selectedMessageLayout = .message
+            }
+        }
+
         func updateBottomVisibility(_ isVisible: Bool) {
             isAtBottom = isVisible
             if isVisible && selectedMessageFilter == .all {
@@ -279,6 +276,7 @@ extension MessageView {
                 selectedMessageFilter = .all
             }
             client.sendMessage(trimmedMessage)
+            requestScrollToBottom()
         }
 
         func handleScenePhaseChange(_ phase: ScenePhase) {
@@ -291,20 +289,6 @@ extension MessageView {
                 break
             @unknown default:
                 break
-            }
-        }
-
-        func updateKeyboardHeight(from notification: Notification) {
-            guard let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
-
-            let screenHeight = UIApplication.shared.connectedScenes
-                .compactMap { ($0 as? UIWindowScene)?.screen.bounds.height }
-                .first ?? keyboardFrame.maxY
-            let overlap = max(0, screenHeight - keyboardFrame.minY)
-            let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double ?? 0.25
-
-            withAnimation(.easeOut(duration: duration)) {
-                keyboardHeight = overlap
             }
         }
 

--- a/penny-client/PennyClient/Views/MessageView+ViewModel.swift
+++ b/penny-client/PennyClient/Views/MessageView+ViewModel.swift
@@ -121,7 +121,6 @@ extension MessageView {
         var isShowingConnectionError = false
         var isShowingSettings = false
         var hasHiddenNewMessages = false
-        var selectedMessageID: Int?
         var selectedMessageLayout: MessageLayout = .message
         var selectedMessageFilter: MessageFilter = .all {
             didSet {

--- a/penny-client/PennyClient/Views/MessageView.swift
+++ b/penny-client/PennyClient/Views/MessageView.swift
@@ -6,6 +6,7 @@ struct MessageView: View {
     @State private var viewModel = ViewModel()
     @State private var isMessageLayoutSwitcherEnabled = Prefs.shared.isMessageLayoutSwitcherEnabled
     @State private var presentedCardMessage: ChatMessage?
+    @State private var keyboardSettledScrollTask: Task<Void, Never>?
     @FocusState private var isComposerFocused: Bool
 
     private var effectiveMessageLayout: MessageLayout {
@@ -28,13 +29,8 @@ struct MessageView: View {
                         .padding(.top, 10)
                 }
             }
-            .overlay(alignment: .bottom) {
+            .safeAreaInset(edge: .bottom) {
                 composer
-                    .offset(y: -viewModel.keyboardOffset)
-                    .readHeight { height in
-                        guard height > 0 else { return }
-                        viewModel.composerHeight = height
-                    }
             }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -80,7 +76,6 @@ struct MessageView: View {
                     }
                 }
             }
-            .ignoresSafeArea(.keyboard, edges: .bottom)
             .alert("Connection Error", isPresented: $viewModel.isShowingConnectionError, presenting: viewModel.client.lastError) { _ in
                 Button("Reconnect") {
                     viewModel.reconnect()
@@ -109,13 +104,11 @@ struct MessageView: View {
             }
             viewModel.handleScenePhaseChange(newPhase)
         }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) { notification in
-            viewModel.updateKeyboardHeight(from: notification)
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
-            viewModel.keyboardHeight = 0
+        .onChange(of: isComposerFocused) { _, isFocused in
+            handleComposerFocusChanged(isFocused)
         }
         .onDisappear {
+            keyboardSettledScrollTask?.cancel()
             viewModel.disconnect()
         }
     }
@@ -126,18 +119,12 @@ struct MessageView: View {
                 VStack(spacing: 12) {
                     olderMessagesLoader(proxy: proxy)
 
+                    topMessageLoader(proxy: proxy)
+
                     if viewModel.displayedMessages.isEmpty {
                         EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
                     } else {
-                        LazyVGrid(columns: MessageLayout.message.gridColumns, spacing: MessageLayout.message.itemSpacing) {
-                            ForEach(viewModel.displayedMessages) { message in
-                                ChatMessageView(message: message, layout: .message)
-                                    .id(message.id)
-                                    .onAppear {
-                                        handleMessageAppeared(message, proxy: proxy)
-                                    }
-                            }
-                        }
+                        messageGrid(layout: .message)
                     }
 
                     if viewModel.client.isTyping && viewModel.shouldShowTypingIndicator {
@@ -150,6 +137,7 @@ struct MessageView: View {
                 .padding(.top, isMessageLayoutSwitcherEnabled ? 58 : 12)
             }
             .background(Color(.systemGroupedBackground))
+            .coordinateSpace(name: messageScrollCoordinateSpace)
             .scrollDismissesKeyboard(.interactively)
             .onAppear {
                 scheduleScrollToBottom(with: proxy, animated: false)
@@ -171,22 +159,12 @@ struct MessageView: View {
                 VStack(spacing: 12) {
                     olderMessagesLoader(proxy: proxy)
 
+                    topMessageLoader(proxy: proxy)
+
                     if viewModel.displayedMessages.isEmpty {
                         EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
                     } else {
-                        LazyVGrid(columns: layout.gridColumns, spacing: layout.itemSpacing) {
-                            ForEach(viewModel.displayedMessages) { message in
-                                ChatMessageView(message: message, layout: layout)
-                                    .id(message.id)
-                                    .contentShape(Rectangle())
-                                    .onAppear {
-                                        handleMessageAppeared(message, proxy: proxy)
-                                    }
-                                    .onTapGesture {
-                                        presentedCardMessage = message
-                                    }
-                                }
-                        }
+                        messageGrid(layout: layout)
                     }
 
                     bottomSpacer
@@ -195,6 +173,7 @@ struct MessageView: View {
                 .padding(.top, isMessageLayoutSwitcherEnabled ? 58 : 12)
             }
             .background(Color(.systemGroupedBackground))
+            .coordinateSpace(name: messageScrollCoordinateSpace)
             .scrollDismissesKeyboard(.interactively)
             .onAppear {
                 scheduleScrollToBottom(with: proxy, animated: false)
@@ -314,9 +293,13 @@ struct MessageView: View {
         "message-list-bottom"
     }
 
+    private var messageScrollCoordinateSpace: String {
+        "message-scroll-coordinate-space"
+    }
+
     private var bottomSpacer: some View {
         Color.clear
-            .frame(height: viewModel.composerHeight + viewModel.keyboardOffset + 12)
+            .frame(height: 1)
             .id(bottomAnchorID)
             .onAppear {
                 viewModel.updateBottomVisibility(true)
@@ -324,6 +307,45 @@ struct MessageView: View {
             .onDisappear {
                 viewModel.updateBottomVisibility(false)
             }
+    }
+
+    @ViewBuilder
+    private func messageGrid(layout: MessageLayout) -> some View {
+        Grid(horizontalSpacing: layout.itemSpacing, verticalSpacing: layout.itemSpacing) {
+            ForEach(messageGridRows(for: layout)) { row in
+                GridRow {
+                    ForEach(row.messages) { message in
+                        messageGridCell(message, layout: layout)
+                    }
+
+                    ForEach(row.messages.count..<layout.columnCount, id: \.self) { _ in
+                        Color.clear
+                            .frame(maxWidth: .infinity)
+                            .accessibilityHidden(true)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func messageGridCell(_ message: ChatMessage, layout: MessageLayout) -> some View {
+        ChatMessageView(message: message, layout: layout)
+            .id(message.id)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                guard layout != .message else { return }
+                presentedCardMessage = message
+            }
+    }
+
+    private func messageGridRows(for layout: MessageLayout) -> [MessageGridRow] {
+        let columnCount = layout.columnCount
+        return stride(from: 0, to: viewModel.displayedMessages.count, by: columnCount).map { startIndex in
+            let endIndex = min(startIndex + columnCount, viewModel.displayedMessages.count)
+            return MessageGridRow(messages: Array(viewModel.displayedMessages[startIndex..<endIndex]))
+        }
     }
 
     @ViewBuilder
@@ -336,12 +358,54 @@ struct MessageView: View {
         }
     }
 
+    private func topMessageLoader(proxy: ScrollViewProxy) -> some View {
+        Color.clear
+            .frame(height: 0)
+            .background {
+                GeometryReader { geometry in
+                    Color.clear
+                        .preference(
+                            key: TopMessageLoaderPreferenceKey.self,
+                            value: geometry.frame(in: .named(messageScrollCoordinateSpace)).minY
+                        )
+                }
+            }
+            .onPreferenceChange(TopMessageLoaderPreferenceKey.self) { minY in
+                guard minY >= 0 else { return }
+                loadOlderMessages(with: proxy)
+            }
+    }
+
     private func refreshFeaturePreferences() {
         isMessageLayoutSwitcherEnabled = Prefs.shared.isMessageLayoutSwitcherEnabled
     }
 
+    private func handleComposerFocusChanged(_ isFocused: Bool) {
+        guard isFocused else {
+            keyboardSettledScrollTask?.cancel()
+            return
+        }
+        if isMessageLayoutSwitcherEnabled {
+            viewModel.prepareComposerFocus()
+        }
+        scheduleScrollAfterKeyboardSettles()
+    }
+
+    private func scheduleScrollAfterKeyboardSettles() {
+        keyboardSettledScrollTask?.cancel()
+        keyboardSettledScrollTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(350))
+            guard !Task.isCancelled && isComposerFocused else { return }
+            viewModel.requestScrollToBottom()
+        }
+    }
+
     private func changeMessageLayout(to layout: MessageLayout) {
         guard viewModel.selectedMessageLayout != layout else { return }
+        if layout != .message {
+            isComposerFocused = false
+            keyboardSettledScrollTask?.cancel()
+        }
 
         var transaction = Transaction(animation: .spring(response: 0.34, dampingFraction: 0.86))
         transaction.disablesAnimations = false
@@ -401,31 +465,24 @@ struct MessageView: View {
         }
     }
 
-    private func handleMessageAppeared(_ message: ChatMessage, proxy: ScrollViewProxy) {
-        guard message.id == viewModel.displayedMessages.first?.id else { return }
-        loadOlderMessages(with: proxy)
+}
+
+private struct MessageGridRow: Identifiable {
+    let messages: [ChatMessage]
+
+    var id: Int {
+        messages.first?.id ?? 0
     }
 }
 
-private struct HeightPreferenceKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
+private struct TopMessageLoaderPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = -.infinity
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
+        value = nextValue()
     }
 }
 
-private extension View {
-    func readHeight(_ onChange: @escaping (CGFloat) -> Void) -> some View {
-        overlay {
-            GeometryReader { proxy in
-                Color.clear
-                    .preference(key: HeightPreferenceKey.self, value: proxy.size.height)
-            }
-        }
-        .onPreferenceChange(HeightPreferenceKey.self, perform: onChange)
-    }
-}
 
 private struct MessageCardDetailSheet: View {
     let message: ChatMessage

--- a/penny-client/PennyClient/Views/MessageView.swift
+++ b/penny-client/PennyClient/Views/MessageView.swift
@@ -4,11 +4,10 @@ import UIKit
 struct MessageView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var viewModel = ViewModel()
-    @State private var scrollToBottomRequest = 0
-    @State private var scrollPosition = ScrollPosition()
-    @State private var scrollMetrics = ScrollMetrics()
-    @State private var pendingLayoutScrollProgress: CGFloat?
     @State private var isMessageLayoutSwitcherEnabled = Prefs.shared.isMessageLayoutSwitcherEnabled
+    @State private var presentedCardMessage: ChatMessage?
+    @State private var scrollToBottomRequest = 0
+    @FocusState private var isComposerFocused: Bool
 
     private var effectiveMessageLayout: MessageLayout {
         isMessageLayoutSwitcherEnabled ? viewModel.selectedMessageLayout : .message
@@ -17,85 +16,19 @@ struct MessageView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        VStack(spacing: 12) {
-                            if viewModel.filteredMessages.isEmpty {
-                                EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
-                            } else {
-                                LazyVGrid(columns: effectiveMessageLayout.gridColumns, spacing: effectiveMessageLayout.itemSpacing) {
-                                    ForEach(viewModel.filteredMessages) { message in
-                                        ChatMessageView(message: message, layout: effectiveMessageLayout, isSelected: viewModel.selectedMessageID == message.id)
-                                            .contentShape(Rectangle())
-                                            .onTapGesture {
-                                                focusMessage(message.id, with: proxy)
-                                            }
-                                            .id(message.id)
-                                    }
-                                }
-                                .scrollTargetLayout()
-                            }
-
-                            if viewModel.client.isTyping && viewModel.shouldShowTypingIndicator && effectiveMessageLayout == .message {
-                                TypingRow()
-                            }
-
-                            Color.clear
-                                .frame(height: viewModel.composerHeight + viewModel.keyboardOffset + 12)
-                                .id(bottomAnchorID)
-                        }
-                        .padding(.horizontal, effectiveMessageLayout.horizontalPadding)
-                        .padding(.top, isMessageLayoutSwitcherEnabled ? 58 : 12)
-                    }
-                    .background(Color(.systemGroupedBackground))
-                    .scrollPosition($scrollPosition)
-                    .onScrollGeometryChange(for: ScrollMetrics.self) { geometry in
-                        ScrollMetrics(geometry: geometry)
-                    } action: { oldMetrics, newMetrics in
-                        scrollMetrics = newMetrics
-                        restorePendingLayoutScrollIfNeeded(oldMetrics: oldMetrics, newMetrics: newMetrics)
-                    }
-                    .overlay(alignment: .top) {
-                        if isMessageLayoutSwitcherEnabled {
-                            messageLayoutSelector
-                                .padding(.top, 10)
-                        }
-                    }
-                    .scrollDismissesKeyboard(.interactively)
-                    .onAppear {
-                        DispatchQueue.main.async {
-                            scrollToBottom(with: proxy, animated: false)
-                        }
-                    }
-                    .onChange(of: viewModel.client.messages.count) { oldCount, _ in
-                        Task {
-                            guard await viewModel.handleMessagesChanged(previousMessageCount: oldCount) else { return }
-
-                            if effectiveMessageLayout == .message {
-                                scrollToBottom(with: proxy)
-                            } else {
-                                viewModel.hasHiddenNewMessages = true
-                            }
-                        }
-                    }
-                    .onChange(of: viewModel.selectedMessageFilter) { _, _ in
-                        Task {
-                            await viewModel.waitForFiltering()
-                            scrollToBottom(with: proxy, animated: false)
-                        }
-                    }
-                    .onChange(of: viewModel.client.isTyping) { _, _ in
-                        scrollToBottom(with: proxy)
-                    }
-                    .onChange(of: scrollToBottomRequest) { _, _ in
-                        scrollToBottom(with: proxy)
-                    }
-                    .onChange(of: viewModel.keyboardHeight) { _, _ in
-                        scrollToBottom(with: proxy)
-                    }
+                if effectiveMessageLayout == .message {
+                    chatScrollView
+                } else {
+                    cardScrollView(layout: effectiveMessageLayout)
                 }
             }
             .background(Color(.systemGroupedBackground).ignoresSafeArea())
+            .overlay(alignment: .top) {
+                if isMessageLayoutSwitcherEnabled {
+                    messageLayoutSelector
+                        .padding(.top, 10)
+                }
+            }
             .overlay(alignment: .bottom) {
                 composer
                     .offset(y: -viewModel.keyboardOffset)
@@ -160,6 +93,9 @@ struct MessageView: View {
             .sheet(isPresented: $viewModel.isShowingSettings) {
                 SettingsView(client: viewModel.client)
             }
+            .sheet(item: $presentedCardMessage) { message in
+                MessageCardDetailSheet(message: message)
+            }
             .onChange(of: viewModel.isShowingSettings) { _, isShowingSettings in
                 guard !isShowingSettings else { return }
                 refreshFeaturePreferences()
@@ -169,6 +105,9 @@ struct MessageView: View {
             await viewModel.connect()
         }
         .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .background {
+                isComposerFocused = false
+            }
             viewModel.handleScenePhaseChange(newPhase)
         }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) { notification in
@@ -179,6 +118,86 @@ struct MessageView: View {
         }
         .onDisappear {
             viewModel.disconnect()
+        }
+    }
+
+    private var chatScrollView: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(spacing: 12) {
+                    if viewModel.filteredMessages.isEmpty {
+                        EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
+                    } else {
+                        LazyVGrid(columns: MessageLayout.message.gridColumns, spacing: MessageLayout.message.itemSpacing) {
+                            ForEach(viewModel.filteredMessages) { message in
+                                ChatMessageView(message: message, layout: .message)
+                                    .id(message.id)
+                            }
+                        }
+                    }
+
+                    if viewModel.client.isTyping && viewModel.shouldShowTypingIndicator {
+                        TypingRow()
+                    }
+
+                    Color.clear
+                        .frame(height: viewModel.composerHeight + viewModel.keyboardOffset + 12)
+                        .id(bottomAnchorID)
+                }
+                .padding(.horizontal, MessageLayout.message.horizontalPadding)
+                .padding(.top, isMessageLayoutSwitcherEnabled ? 58 : 12)
+            }
+            .background(Color(.systemGroupedBackground))
+            .scrollDismissesKeyboard(.interactively)
+            .onAppear {
+                DispatchQueue.main.async {
+                    scrollToBottom(with: proxy, animated: false)
+                }
+            }
+            .onChange(of: viewModel.client.messages.count) { oldCount, _ in
+                Task {
+                    guard await viewModel.handleMessagesChanged(previousMessageCount: oldCount) else { return }
+                    scrollToBottom(with: proxy)
+                }
+            }
+            .onChange(of: viewModel.client.isTyping) { _, _ in
+                scrollToBottom(with: proxy)
+            }
+            .onChange(of: scrollToBottomRequest) { _, _ in
+                scrollToBottom(with: proxy)
+            }
+        }
+    }
+
+    private func cardScrollView(layout: MessageLayout) -> some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                if viewModel.filteredMessages.isEmpty {
+                    EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
+                } else {
+                    LazyVGrid(columns: layout.gridColumns, spacing: layout.itemSpacing) {
+                        ForEach(viewModel.filteredMessages) { message in
+                            ChatMessageView(message: message, layout: layout)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    presentedCardMessage = message
+                                }
+                        }
+                    }
+                }
+
+                Color.clear
+                    .frame(height: viewModel.composerHeight + viewModel.keyboardOffset + 12)
+            }
+            .padding(.horizontal, layout.horizontalPadding)
+            .padding(.top, isMessageLayoutSwitcherEnabled ? 58 : 12)
+        }
+        .background(Color(.systemGroupedBackground))
+        .scrollDismissesKeyboard(.interactively)
+        .onChange(of: viewModel.client.messages.count) { oldCount, _ in
+            Task {
+                _ = await viewModel.handleMessagesChanged(previousMessageCount: oldCount)
+            }
         }
     }
 
@@ -205,6 +224,7 @@ struct MessageView: View {
         Button {
             Task {
                 await viewModel.clearFiltersAndShowNewMessages()
+                viewModel.selectedMessageLayout = .message
                 scrollToBottomRequest += 1
             }
         } label: {
@@ -266,6 +286,7 @@ struct MessageView: View {
                 .font(.body)
                 .lineLimit(1...5)
                 .submitLabel(.send)
+                .focused($isComposerFocused)
                 .onSubmit(viewModel.sendDraft)
                 .padding(.horizontal, 18)
                 .padding(.vertical, 12)
@@ -296,42 +317,11 @@ struct MessageView: View {
 
     private func changeMessageLayout(to layout: MessageLayout) {
         guard viewModel.selectedMessageLayout != layout else { return }
-        pendingLayoutScrollProgress = scrollMetrics.progress
 
         var transaction = Transaction(animation: .spring(response: 0.34, dampingFraction: 0.86))
         transaction.disablesAnimations = false
         withTransaction(transaction) {
             viewModel.selectedMessageLayout = layout
-        }
-    }
-
-    private func restorePendingLayoutScrollIfNeeded(oldMetrics: ScrollMetrics, newMetrics: ScrollMetrics) {
-        guard let progress = pendingLayoutScrollProgress else { return }
-        guard oldMetrics.contentHeight != newMetrics.contentHeight else { return }
-
-        pendingLayoutScrollProgress = nil
-        let restoredOffset = newMetrics.maxOffsetY * progress
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            scrollPosition.scrollTo(point: CGPoint(x: 0, y: restoredOffset))
-        }
-    }
-
-    private func focusMessage(_ messageID: Int, with proxy: ScrollViewProxy) {
-        viewModel.selectedMessageID = messageID
-        guard isMessageLayoutSwitcherEnabled && viewModel.selectedMessageLayout != .message else { return }
-
-        var transaction = Transaction(animation: .spring(response: 0.34, dampingFraction: 0.86))
-        transaction.disablesAnimations = false
-        withTransaction(transaction) {
-            viewModel.selectedMessageLayout = .message
-        }
-
-        DispatchQueue.main.async {
-            DispatchQueue.main.async {
-                proxy.scrollTo(messageID, anchor: .center)
-            }
         }
     }
 
@@ -343,25 +333,6 @@ struct MessageView: View {
         } else {
             proxy.scrollTo(bottomAnchorID, anchor: .bottom)
         }
-    }
-}
-
-private struct ScrollMetrics: Equatable {
-    var offsetY: CGFloat = 0
-    var maxOffsetY: CGFloat = 0
-    var contentHeight: CGFloat = 0
-
-    var progress: CGFloat {
-        guard maxOffsetY > 0 else { return 0 }
-        return min(max(offsetY / maxOffsetY, 0), 1)
-    }
-
-    init() {}
-
-    init(geometry: ScrollGeometry) {
-        offsetY = max(geometry.visibleRect.minY, 0)
-        maxOffsetY = max(geometry.contentSize.height - geometry.containerSize.height, 0)
-        contentHeight = geometry.contentSize.height
     }
 }
 
@@ -382,6 +353,30 @@ private extension View {
             }
         }
         .onPreferenceChange(HeightPreferenceKey.self, perform: onChange)
+    }
+}
+
+private struct MessageCardDetailSheet: View {
+    let message: ChatMessage
+
+    private var title: String {
+        guard let sourceHint = message.sourceHint, !sourceHint.isEmpty else {
+            return message.isOutgoing ? "You" : "Message"
+        }
+        return sourceHint
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                ChatMessageView(message: message, layout: .message, showsSourceHintInline: false, fillsMessageRowWidth: true)
+                    .padding(.horizontal, MessageView.MessageLayout.message.horizontalPadding)
+                    .padding(.vertical, 16)
+            }
+            .background(Color(.systemGroupedBackground))
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
     }
 }
 

--- a/penny-client/PennyClient/Views/MessageView.swift
+++ b/penny-client/PennyClient/Views/MessageView.swift
@@ -6,7 +6,6 @@ struct MessageView: View {
     @State private var viewModel = ViewModel()
     @State private var isMessageLayoutSwitcherEnabled = Prefs.shared.isMessageLayoutSwitcherEnabled
     @State private var presentedCardMessage: ChatMessage?
-    @State private var scrollToBottomRequest = 0
     @FocusState private var isComposerFocused: Bool
 
     private var effectiveMessageLayout: MessageLayout {
@@ -125,13 +124,18 @@ struct MessageView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(spacing: 12) {
-                    if viewModel.filteredMessages.isEmpty {
+                    olderMessagesLoader(proxy: proxy)
+
+                    if viewModel.displayedMessages.isEmpty {
                         EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
                     } else {
                         LazyVGrid(columns: MessageLayout.message.gridColumns, spacing: MessageLayout.message.itemSpacing) {
-                            ForEach(viewModel.filteredMessages) { message in
+                            ForEach(viewModel.displayedMessages) { message in
                                 ChatMessageView(message: message, layout: .message)
                                     .id(message.id)
+                                    .onAppear {
+                                        handleMessageAppeared(message, proxy: proxy)
+                                    }
                             }
                         }
                     }
@@ -140,9 +144,7 @@ struct MessageView: View {
                         TypingRow()
                     }
 
-                    Color.clear
-                        .frame(height: viewModel.composerHeight + viewModel.keyboardOffset + 12)
-                        .id(bottomAnchorID)
+                    bottomSpacer
                 }
                 .padding(.horizontal, MessageLayout.message.horizontalPadding)
                 .padding(.top, isMessageLayoutSwitcherEnabled ? 58 : 12)
@@ -150,53 +152,55 @@ struct MessageView: View {
             .background(Color(.systemGroupedBackground))
             .scrollDismissesKeyboard(.interactively)
             .onAppear {
-                DispatchQueue.main.async {
-                    scrollToBottom(with: proxy, animated: false)
-                }
-            }
-            .onChange(of: viewModel.client.messages.count) { oldCount, _ in
-                Task {
-                    guard await viewModel.handleMessagesChanged(previousMessageCount: oldCount) else { return }
-                    scrollToBottom(with: proxy)
-                }
+                scheduleScrollToBottom(with: proxy, animated: false)
             }
             .onChange(of: viewModel.client.isTyping) { _, _ in
-                scrollToBottom(with: proxy)
+                if viewModel.isAtBottom {
+                    scheduleScrollToBottom(with: proxy, shouldSettleLayout: false)
+                }
             }
-            .onChange(of: scrollToBottomRequest) { _, _ in
-                scrollToBottom(with: proxy)
+            .onChange(of: viewModel.scrollToBottomRequest) { _, _ in
+                scheduleScrollToBottom(with: proxy, animated: false)
             }
         }
     }
 
     private func cardScrollView(layout: MessageLayout) -> some View {
-        ScrollView {
-            VStack(spacing: 12) {
-                if viewModel.filteredMessages.isEmpty {
-                    EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
-                } else {
-                    LazyVGrid(columns: layout.gridColumns, spacing: layout.itemSpacing) {
-                        ForEach(viewModel.filteredMessages) { message in
-                            ChatMessageView(message: message, layout: layout)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    presentedCardMessage = message
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(spacing: 12) {
+                    olderMessagesLoader(proxy: proxy)
+
+                    if viewModel.displayedMessages.isEmpty {
+                        EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
+                    } else {
+                        LazyVGrid(columns: layout.gridColumns, spacing: layout.itemSpacing) {
+                            ForEach(viewModel.displayedMessages) { message in
+                                ChatMessageView(message: message, layout: layout)
+                                    .id(message.id)
+                                    .contentShape(Rectangle())
+                                    .onAppear {
+                                        handleMessageAppeared(message, proxy: proxy)
+                                    }
+                                    .onTapGesture {
+                                        presentedCardMessage = message
+                                    }
                                 }
                         }
                     }
-                }
 
-                Color.clear
-                    .frame(height: viewModel.composerHeight + viewModel.keyboardOffset + 12)
+                    bottomSpacer
+                }
+                .padding(.horizontal, layout.horizontalPadding)
+                .padding(.top, isMessageLayoutSwitcherEnabled ? 58 : 12)
             }
-            .padding(.horizontal, layout.horizontalPadding)
-            .padding(.top, isMessageLayoutSwitcherEnabled ? 58 : 12)
-        }
-        .background(Color(.systemGroupedBackground))
-        .scrollDismissesKeyboard(.interactively)
-        .onChange(of: viewModel.client.messages.count) { oldCount, _ in
-            Task {
-                _ = await viewModel.handleMessagesChanged(previousMessageCount: oldCount)
+            .background(Color(.systemGroupedBackground))
+            .scrollDismissesKeyboard(.interactively)
+            .onAppear {
+                scheduleScrollToBottom(with: proxy, animated: false)
+            }
+            .onChange(of: viewModel.scrollToBottomRequest) { _, _ in
+                scheduleScrollToBottom(with: proxy, animated: false)
             }
         }
     }
@@ -225,7 +229,6 @@ struct MessageView: View {
             Task {
                 await viewModel.clearFiltersAndShowNewMessages()
                 viewModel.selectedMessageLayout = .message
-                scrollToBottomRequest += 1
             }
         } label: {
             Image(systemName: "message.badge")
@@ -311,6 +314,28 @@ struct MessageView: View {
         "message-list-bottom"
     }
 
+    private var bottomSpacer: some View {
+        Color.clear
+            .frame(height: viewModel.composerHeight + viewModel.keyboardOffset + 12)
+            .id(bottomAnchorID)
+            .onAppear {
+                viewModel.updateBottomVisibility(true)
+            }
+            .onDisappear {
+                viewModel.updateBottomVisibility(false)
+            }
+    }
+
+    @ViewBuilder
+    private func olderMessagesLoader(proxy: ScrollViewProxy) -> some View {
+        if viewModel.isLoadingOlderMessages {
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+        }
+    }
+
     private func refreshFeaturePreferences() {
         isMessageLayoutSwitcherEnabled = Prefs.shared.isMessageLayoutSwitcherEnabled
     }
@@ -323,9 +348,32 @@ struct MessageView: View {
         withTransaction(transaction) {
             viewModel.selectedMessageLayout = layout
         }
+        viewModel.requestScrollToBottom()
     }
 
-    private func scrollToBottom(with proxy: ScrollViewProxy, animated: Bool = true) {
+    private func scheduleScrollToBottom(
+        with proxy: ScrollViewProxy,
+        animated: Bool = true,
+        shouldSettleLayout: Bool = true
+    ) {
+        let delays: [TimeInterval] = shouldSettleLayout ? [0.05, 0.16, 0.35] : [0.05]
+
+        for (index, delay) in delays.enumerated() {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                scrollToBottom(
+                    with: proxy,
+                    animated: animated && index == 0,
+                    enableOlderPaging: index == delays.count - 1
+                )
+            }
+        }
+    }
+
+    private func scrollToBottom(
+        with proxy: ScrollViewProxy,
+        animated: Bool = true,
+        enableOlderPaging: Bool = true
+    ) {
         if animated {
             withAnimation(.easeOut(duration: 0.2)) {
                 proxy.scrollTo(bottomAnchorID, anchor: .bottom)
@@ -333,6 +381,29 @@ struct MessageView: View {
         } else {
             proxy.scrollTo(bottomAnchorID, anchor: .bottom)
         }
+
+        if enableOlderPaging && !viewModel.displayedMessages.isEmpty {
+            viewModel.enableOlderPaging()
+        }
+    }
+
+    private func loadOlderMessages(with proxy: ScrollViewProxy) {
+        guard let anchorID = viewModel.reserveOlderMessageLoad() else { return }
+        Task {
+            guard await viewModel.loadReservedOlderMessages() else { return }
+            try? await Task.sleep(for: .milliseconds(16))
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                proxy.scrollTo(anchorID, anchor: .top)
+            }
+            viewModel.finishOlderMessageScrollRestoration()
+        }
+    }
+
+    private func handleMessageAppeared(_ message: ChatMessage, proxy: ScrollViewProxy) {
+        guard message.id == viewModel.displayedMessages.first?.id else { return }
+        loadOlderMessages(with: proxy)
     }
 }
 

--- a/penny-client/PennyClientTests/DatabaseServiceTests.swift
+++ b/penny-client/PennyClientTests/DatabaseServiceTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import PennyClient
 
 @Suite(.serialized)
+@MainActor
 struct DatabaseServiceTests {
     @Test func savesAndLoadsMessagesIncludingAttachments() {
         let database = DatabaseService()
@@ -41,4 +42,85 @@ struct DatabaseServiceTests {
 
         #expect(loaded.map(\.content) == ["First", "Second"])
     }
+
+    @Test func latestMessagePageReturnsNewestMessagesInDisplayOrder() {
+        let database = DatabaseService()
+        database.setupForTesting()
+        saveNumberedMessages(in: database, ids: 1...5)
+
+        let page = database.loadMessagePage(MessagePageRequest(limit: 2, filter: .all))
+
+        #expect(page.messages.map(\.id) == [4, 5])
+        #expect(page.nextCursor == MessagePageCursor(createdAt: Date(timeIntervalSince1970: 4), id: 4))
+        #expect(page.hasMore)
+    }
+
+    @Test func olderMessagePageUsesCursorWithoutOverlap() {
+        let database = DatabaseService()
+        database.setupForTesting()
+        saveNumberedMessages(in: database, ids: 1...5)
+        let latestPage = database.loadMessagePage(MessagePageRequest(limit: 2, filter: .all))
+
+        let olderPage = database.loadMessagePage(MessagePageRequest(limit: 2, before: latestPage.nextCursor, filter: .all))
+        let oldestPage = database.loadMessagePage(MessagePageRequest(limit: 2, before: olderPage.nextCursor, filter: .all))
+
+        #expect(olderPage.messages.map(\.id) == [2, 3])
+        #expect(olderPage.hasMore)
+        #expect(oldestPage.messages.map(\.id) == [1])
+        #expect(oldestPage.hasMore == false)
+    }
+
+    @Test func messagePagesApplySourceFilters() {
+        let database = DatabaseService()
+        database.setupForTesting()
+        database.save(message: makeMessage(id: 1, content: "Penny", sourceHint: "Penny"))
+        database.save(message: makeMessage(id: 2, content: "Startup", sourceHint: "Startup"))
+        database.save(message: makeMessage(id: 3, content: "Schedule", sourceHint: "Schedule"))
+        database.save(message: makeMessage(id: 4, content: "Chat", sourceHint: "Chat"))
+        database.save(message: makeMessage(id: 5, content: "Test Push", sourceHint: "Test Push"))
+        database.save(message: makeMessage(id: 6, content: "Notifier", sourceHint: "Notifier"))
+        database.save(message: makeMessage(id: 7, content: "Collector", sourceHint: "Collector: flight-deals"))
+        database.save(message: makeMessage(id: 8, serverID: nil, content: "Outgoing", isOutgoing: true))
+
+        #expect(database.loadMessagePage(MessagePageRequest(limit: 20, filter: .penny)).messages.map(\.id) == [1, 2, 5])
+        #expect(database.loadMessagePage(MessagePageRequest(limit: 20, filter: .schedule)).messages.map(\.id) == [3])
+        #expect(database.loadMessagePage(MessagePageRequest(limit: 20, filter: .chat)).messages.map(\.id) == [4, 8])
+        #expect(database.loadMessagePage(MessagePageRequest(limit: 20, filter: .notifier)).messages.map(\.id) == [6])
+        #expect(database.loadMessagePage(MessagePageRequest(limit: 20, filter: .collector)).messages.map(\.id) == [7])
+    }
+
+    @Test func messageIdentityHelpersUsePersistedRows() {
+        let database = DatabaseService()
+        database.setupForTesting()
+        database.save(message: makeMessage(id: -3, serverID: nil, content: "Local", isOutgoing: true))
+        database.save(message: makeMessage(id: 10, serverID: 10, content: "Remote"))
+
+        #expect(database.minimumMessageID() == -3)
+        #expect(database.containsMessage(serverID: 10))
+        #expect(database.containsMessage(serverID: 11) == false)
+    }
+}
+
+private func saveNumberedMessages(in database: DatabaseService, ids: ClosedRange<Int>) {
+    for id in ids {
+        database.save(message: makeMessage(id: id, content: "Message \(id)"))
+    }
+}
+
+private func makeMessage(
+    id: Int,
+    serverID: Int? = nil,
+    content: String,
+    sourceHint: String? = nil,
+    isOutgoing: Bool = false
+) -> MessageModel {
+    MessageModel(
+        id: id,
+        serverID: serverID ?? (isOutgoing ? nil : id),
+        createdAt: Date(timeIntervalSince1970: TimeInterval(id)),
+        content: content,
+        sourceHint: sourceHint,
+        imageAttachmentDataURLs: [],
+        isOutgoing: isOutgoing
+    )
 }

--- a/penny-client/PennyClientTests/MessageViewModelTests.swift
+++ b/penny-client/PennyClientTests/MessageViewModelTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Testing
-import UIKit
 @testable import PennyClient
 
 @Suite(.serialized)
@@ -20,6 +19,27 @@ struct MessageViewModelTests {
 
         viewModel.selectedMessageLayout = .media
         #expect(viewModel.selectedMessageLayout == .media)
+    }
+
+    @Test func composerFocusReturnsToMessageLayoutWithoutRequestingScroll() {
+        let viewModel = MessageView.ViewModel(client: PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs()))
+        viewModel.selectedMessageLayout = .media
+        let previousScrollRequest = viewModel.scrollToBottomRequest
+
+        viewModel.prepareComposerFocus()
+
+        #expect(viewModel.selectedMessageLayout == .message)
+        #expect(viewModel.scrollToBottomRequest == previousScrollRequest)
+    }
+
+    @Test func composerFocusDoesNotRequestScrollWhenAlreadyUsingMessageLayout() {
+        let viewModel = MessageView.ViewModel(client: PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs()))
+        let previousScrollRequest = viewModel.scrollToBottomRequest
+
+        viewModel.prepareComposerFocus()
+
+        #expect(viewModel.selectedMessageLayout == .message)
+        #expect(viewModel.scrollToBottomRequest == previousScrollRequest)
     }
 
     @Test func startupLoadsLatestPageOnly() async {
@@ -144,6 +164,8 @@ struct MessageViewModelTests {
         await viewModel.connect()
         viewModel.selectedMessageFilter = .penny
         await viewModel.waitForPaging()
+        viewModel.updateBottomVisibility(false)
+        let previousScrollRequest = viewModel.scrollToBottomRequest
         viewModel.draftMessage = "  hello Penny  "
 
         viewModel.sendDraft()
@@ -153,6 +175,8 @@ struct MessageViewModelTests {
         #expect(viewModel.draftMessage.isEmpty)
         #expect(viewModel.displayedMessages.map(\.content) == ["hello Penny"])
         #expect(database.loadMessages().first?.content == "hello Penny")
+        #expect(viewModel.scrollToBottomRequest > previousScrollRequest)
+        #expect(viewModel.isAtBottom)
     }
 
     @Test func sendDraftIgnoresWhitespaceOnlyDraft() {
@@ -242,14 +266,6 @@ struct MessageViewModelTests {
         #expect(viewModel.shouldShowTypingIndicator == false)
     }
 
-    @Test func keyboardOffsetOnlyAppliesWhenKeyboardVisible() {
-        let viewModel = MessageView.ViewModel(client: PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs()))
-
-        #expect(viewModel.keyboardOffset == 0)
-
-        viewModel.keyboardHeight = 300
-        #expect(viewModel.keyboardOffset == 276)
-    }
 }
 
 @MainActor

--- a/penny-client/PennyClientTests/MessageViewModelTests.swift
+++ b/penny-client/PennyClientTests/MessageViewModelTests.swift
@@ -22,30 +22,137 @@ struct MessageViewModelTests {
         #expect(viewModel.selectedMessageLayout == .media)
     }
 
-    @Test func sendDraftTrimsMessageAndClearsDraft() {
+    @Test func startupLoadsLatestPageOnly() async {
         let database = configuredDatabase()
-        let client = PennyWebSocketClient(databaseService: database, prefs: configuredPrefs())
-        let viewModel = MessageView.ViewModel(client: client)
+        saveNumberedMessages(in: database, ids: 1...5)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 2)
+
+        await viewModel.connect()
+
+        #expect(viewModel.displayedMessages.map(\.id) == [4, 5])
+        #expect(viewModel.hasMoreOlderMessages)
+    }
+
+    @Test func scrollingUpPrependsOlderMessages() async {
+        let database = configuredDatabase()
+        saveNumberedMessages(in: database, ids: 1...5)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 2)
+        await viewModel.connect()
+        viewModel.enableOlderPaging()
+
+        let anchorID = viewModel.reserveOlderMessageLoad()
+        let didLoad = await viewModel.loadReservedOlderMessages()
+
+        #expect(anchorID == 4)
+        #expect(didLoad)
+        #expect(viewModel.displayedMessages.map(\.id) == [2, 3, 4, 5])
+        #expect(viewModel.hasMoreOlderMessages)
+    }
+
+    @Test func olderMessageLoadReservationIgnoresDuplicateTriggers() async {
+        let database = configuredDatabase()
+        saveNumberedMessages(in: database, ids: 1...5)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 2)
+        await viewModel.connect()
+        viewModel.enableOlderPaging()
+
+        let firstAnchorID = viewModel.reserveOlderMessageLoad()
+        let secondAnchorID = viewModel.reserveOlderMessageLoad()
+        let didLoad = await viewModel.loadReservedOlderMessages()
+        let thirdAnchorID = viewModel.reserveOlderMessageLoad()
+        viewModel.finishOlderMessageScrollRestoration()
+        let fourthAnchorID = viewModel.reserveOlderMessageLoad()
+
+        #expect(firstAnchorID == 4)
+        #expect(secondAnchorID == nil)
+        #expect(didLoad)
+        #expect(thirdAnchorID == nil)
+        #expect(fourthAnchorID == 2)
+        #expect(viewModel.displayedMessages.map(\.id) == [2, 3, 4, 5])
+    }
+
+    @Test func bottomScrollRequestBlocksOlderPagingUntilScrollLands() async {
+        let database = configuredDatabase()
+        saveNumberedMessages(in: database, ids: 1...5)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 2)
+        await viewModel.connect()
+        viewModel.enableOlderPaging()
+
+        viewModel.requestScrollToBottom()
+        let anchorID = viewModel.reserveOlderMessageLoad()
+
+        #expect(anchorID == nil)
+    }
+
+    @Test func filterChangeCancelsReservedOlderMessageLoad() async {
+        let database = configuredDatabase()
+        saveFilterFixture(in: database)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 2)
+        await viewModel.connect()
+        viewModel.enableOlderPaging()
+
+        let anchorID = viewModel.reserveOlderMessageLoad()
+        viewModel.selectedMessageFilter = .penny
+        await viewModel.waitForPaging()
+        let didLoad = await viewModel.loadReservedOlderMessages()
+
+        #expect(anchorID == 7)
+        #expect(didLoad == false)
+        #expect(viewModel.displayedMessages.map(\.id) == [2, 5])
+        #expect(viewModel.hasMoreOlderMessages)
+    }
+
+    @Test func filterReloadRequestsBottomScrollAndDisablesOlderPagingUntilScrollLands() async {
+        let database = configuredDatabase()
+        saveFilterFixture(in: database)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 2)
+        await viewModel.connect()
+        viewModel.enableOlderPaging()
+        let previousScrollRequest = viewModel.scrollToBottomRequest
+
+        viewModel.selectedMessageFilter = .penny
+        await viewModel.waitForPaging()
+        let blockedAnchorID = viewModel.reserveOlderMessageLoad()
+        viewModel.enableOlderPaging()
+        let unblockedAnchorID = viewModel.reserveOlderMessageLoad()
+
+        #expect(viewModel.scrollToBottomRequest == previousScrollRequest + 1)
+        #expect(viewModel.hasMoreOlderMessages)
+        #expect(blockedAnchorID == nil)
+        #expect(unblockedAnchorID == 2)
+    }
+
+    @Test func changingFiltersReloadsLatestFilteredPage() async {
+        let database = configuredDatabase()
+        saveFilterFixture(in: database)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 20)
+        await viewModel.connect()
+
+        viewModel.selectedMessageFilter = .penny
+        await viewModel.waitForPaging()
+        #expect(viewModel.displayedMessages.map(\.id) == [1, 2, 5])
+
+        viewModel.selectedMessageFilter = .chat
+        await viewModel.waitForPaging()
+        #expect(viewModel.displayedMessages.map(\.id) == [4, 8])
+        #expect(viewModel.hasMoreOlderMessages == false)
+    }
+
+    @Test func sendDraftTrimsMessageClearsDraftAndFilter() async {
+        let database = configuredDatabase()
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 20)
+        await viewModel.connect()
+        viewModel.selectedMessageFilter = .penny
+        await viewModel.waitForPaging()
         viewModel.draftMessage = "  hello Penny  "
 
         viewModel.sendDraft()
-
-        #expect(viewModel.draftMessage.isEmpty)
-        #expect(client.messages.first?.content == "hello Penny")
-        #expect(database.loadMessages().first?.content == "hello Penny")
-    }
-
-    @Test func sendDraftClearsFilters() async {
-        let client = PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs())
-        let viewModel = MessageView.ViewModel(client: client)
-        viewModel.selectedMessageFilter = .penny
-        viewModel.draftMessage = "hello Penny"
-
-        viewModel.sendDraft()
-        await viewModel.waitForFiltering()
+        await viewModel.waitForPaging()
 
         #expect(viewModel.selectedMessageFilter == .all)
-        #expect(viewModel.filteredMessages.map(\.content) == ["hello Penny"])
+        #expect(viewModel.draftMessage.isEmpty)
+        #expect(viewModel.displayedMessages.map(\.content) == ["hello Penny"])
+        #expect(database.loadMessages().first?.content == "hello Penny")
     }
 
     @Test func sendDraftIgnoresWhitespaceOnlyDraft() {
@@ -61,93 +168,63 @@ struct MessageViewModelTests {
         #expect(client.messages.isEmpty)
     }
 
-    @Test func filteredMessagesReflectSelectedFilter() async {
-        let client = PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs())
-        client.messages = [
-            ChatMessage(id: 1, serverID: 1, createdAt: Date(timeIntervalSince1970: 1), content: "Penny", sourceHint: "Penny", imageAttachments: [], isOutgoing: false),
-            ChatMessage(id: 2, serverID: 2, createdAt: Date(timeIntervalSince1970: 2), content: "Startup", sourceHint: "Startup", imageAttachments: [], isOutgoing: false),
-            ChatMessage(id: 3, serverID: 3, createdAt: Date(timeIntervalSince1970: 3), content: "Schedule", sourceHint: "Schedule", imageAttachments: [], isOutgoing: false),
-            ChatMessage(id: 4, serverID: 4, createdAt: Date(timeIntervalSince1970: 4), content: "Chat", sourceHint: "Chat", imageAttachments: [], isOutgoing: false),
-            ChatMessage(id: 5, serverID: 5, createdAt: Date(timeIntervalSince1970: 5), content: "Test Push", sourceHint: "Test Push", imageAttachments: [], isOutgoing: false),
-            ChatMessage(id: 6, serverID: 6, createdAt: Date(timeIntervalSince1970: 6), content: "Notifier", sourceHint: "Notifier", imageAttachments: [], isOutgoing: false),
-            ChatMessage(id: 7, serverID: 7, createdAt: Date(timeIntervalSince1970: 7), content: "Collector", sourceHint: "Collector: flight-deals", imageAttachments: [], isOutgoing: false),
-            ChatMessage(id: 8, serverID: nil, createdAt: Date(timeIntervalSince1970: 8), content: "Outgoing", sourceHint: nil, imageAttachments: [], isOutgoing: true)
-        ]
-        let viewModel = MessageView.ViewModel(client: client)
+    @Test func visibleLiveMessagesSetBadgeInsteadOfScrollingWhenReadingHistory() async {
+        let database = configuredDatabase()
+        saveNumberedMessages(in: database, ids: 1...2)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 20)
+        await viewModel.connect()
+        viewModel.updateBottomVisibility(false)
+        let previousScrollRequest = viewModel.scrollToBottomRequest
 
-        #expect(viewModel.filteredMessages.map(\.id) == [1, 2, 3, 4, 5, 6, 7, 8])
+        viewModel.client.sendMessage("Live message")
 
-        viewModel.selectedMessageFilter = .penny
-        await viewModel.waitForFiltering()
-        #expect(viewModel.filteredMessages.map(\.id) == [1, 2, 5])
-
-        viewModel.selectedMessageFilter = .schedule
-        await viewModel.waitForFiltering()
-        #expect(viewModel.filteredMessages.map(\.id) == [3])
-
-        viewModel.selectedMessageFilter = .chat
-        await viewModel.waitForFiltering()
-        #expect(viewModel.filteredMessages.map(\.id) == [4, 8])
-
-        viewModel.selectedMessageFilter = .notifier
-        await viewModel.waitForFiltering()
-        #expect(viewModel.filteredMessages.map(\.id) == [6])
-
-        viewModel.selectedMessageFilter = .collector
-        await viewModel.waitForFiltering()
-        #expect(viewModel.filteredMessages.map(\.id) == [7])
-    }
-
-    @Test func hiddenNewMessagesDoNotRequestScroll() async {
-        let client = PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs())
-        client.messages = [
-            ChatMessage(id: 1, serverID: 1, createdAt: Date(timeIntervalSince1970: 1), content: "Chat", sourceHint: "Chat", imageAttachments: [], isOutgoing: false)
-        ]
-        let viewModel = MessageView.ViewModel(client: client)
-        viewModel.selectedMessageFilter = .chat
-        await viewModel.waitForFiltering()
-        client.messages.append(ChatMessage(id: 2, serverID: 2, createdAt: Date(timeIntervalSince1970: 2), content: "Schedule", sourceHint: "Schedule", imageAttachments: [], isOutgoing: false))
-
-        let shouldScroll = await viewModel.handleMessagesChanged(previousMessageCount: 1)
-
-        #expect(shouldScroll == false)
+        #expect(viewModel.displayedMessages.map(\.content).last == "Live message")
         #expect(viewModel.hasHiddenNewMessages)
-        #expect(viewModel.filteredMessages.map(\.id) == [1])
+        #expect(viewModel.scrollToBottomRequest == previousScrollRequest)
     }
 
-    @Test func visibleNewMessagesRequestScrollAfterFiltering() async {
-        let client = PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs())
-        client.messages = [
-            ChatMessage(id: 1, serverID: 1, createdAt: Date(timeIntervalSince1970: 1), content: "Chat", sourceHint: "Chat", imageAttachments: [], isOutgoing: false)
-        ]
-        let viewModel = MessageView.ViewModel(client: client)
-        viewModel.selectedMessageFilter = .chat
-        await viewModel.waitForFiltering()
-        client.messages.append(ChatMessage(id: 2, serverID: nil, createdAt: Date(timeIntervalSince1970: 2), content: "Outgoing", sourceHint: nil, imageAttachments: [], isOutgoing: true))
+    @Test func visibleLiveMessagesRequestScrollWhenAlreadyAtBottom() async {
+        let database = configuredDatabase()
+        saveNumberedMessages(in: database, ids: 1...2)
+        let (viewModel, _) = makePagingViewModel(database: database, pageSize: 20)
+        await viewModel.connect()
+        viewModel.updateBottomVisibility(true)
+        let previousScrollRequest = viewModel.scrollToBottomRequest
 
-        let shouldScroll = await viewModel.handleMessagesChanged(previousMessageCount: 1)
+        viewModel.client.sendMessage("Live message")
 
-        #expect(shouldScroll)
+        #expect(viewModel.displayedMessages.map(\.content).last == "Live message")
         #expect(viewModel.hasHiddenNewMessages == false)
-        #expect(viewModel.filteredMessages.map(\.id) == [1, 2])
+        #expect(viewModel.scrollToBottomRequest == previousScrollRequest + 1)
+    }
+
+    @Test func filteredLiveMessagesShowBadgeWithoutAppending() async {
+        let database = configuredDatabase()
+        let (viewModel, transport) = makePagingViewModel(database: database, pageSize: 20)
+        await viewModel.connect()
+        viewModel.selectedMessageFilter = .chat
+        await viewModel.waitForPaging()
+
+        transport.emit(messageID: 20, content: "Schedule update", sourceHint: "Schedule")
+
+        #expect(viewModel.displayedMessages.isEmpty)
+        #expect(viewModel.hasHiddenNewMessages)
+        #expect(database.containsMessage(serverID: 20))
     }
 
     @Test func clearingFiltersShowsHiddenNewMessages() async {
-        let client = PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs())
-        client.messages = [
-            ChatMessage(id: 1, serverID: 1, createdAt: Date(timeIntervalSince1970: 1), content: "Chat", sourceHint: "Chat", imageAttachments: [], isOutgoing: false)
-        ]
-        let viewModel = MessageView.ViewModel(client: client)
+        let database = configuredDatabase()
+        let (viewModel, transport) = makePagingViewModel(database: database, pageSize: 20)
+        await viewModel.connect()
         viewModel.selectedMessageFilter = .chat
-        await viewModel.waitForFiltering()
-        client.messages.append(ChatMessage(id: 2, serverID: 2, createdAt: Date(timeIntervalSince1970: 2), content: "Schedule", sourceHint: "Schedule", imageAttachments: [], isOutgoing: false))
-        _ = await viewModel.handleMessagesChanged(previousMessageCount: 1)
+        await viewModel.waitForPaging()
+        transport.emit(messageID: 20, content: "Schedule update", sourceHint: "Schedule")
 
         await viewModel.clearFiltersAndShowNewMessages()
 
         #expect(viewModel.selectedMessageFilter == .all)
         #expect(viewModel.hasHiddenNewMessages == false)
-        #expect(viewModel.filteredMessages.map(\.id) == [1, 2])
+        #expect(viewModel.displayedMessages.map(\.content) == ["Schedule update"])
     }
 
     @Test func typingIndicatorVisibilityReflectsSelectedFilter() {
@@ -173,4 +250,94 @@ struct MessageViewModelTests {
         viewModel.keyboardHeight = 300
         #expect(viewModel.keyboardOffset == 276)
     }
+}
+
+@MainActor
+private final class MessageViewModelMockTransport: WebSocketTransport {
+    private var onReceive: WebSocketTransport.ReceiveHandler?
+    private var onFailure: WebSocketTransport.FailureHandler?
+    var isConnected = false
+
+    func connect(
+        request: URLRequest,
+        onReceive: @escaping WebSocketTransport.ReceiveHandler,
+        onFailure: @escaping WebSocketTransport.FailureHandler
+    ) {
+        self.onReceive = onReceive
+        self.onFailure = onFailure
+        isConnected = true
+    }
+
+    func disconnect() {
+        onReceive = nil
+        onFailure = nil
+        isConnected = false
+    }
+
+    func send(_ data: Data) async throws {}
+
+    func emit(messageID: Int, content: String, sourceHint: String) {
+        onReceive?(Data("""
+        {
+          "type": "messages",
+          "messages": [
+            {
+              "id": \(messageID),
+              "created_at": "2026-07-05T00:00:00Z",
+              "content": "\(content)",
+              "source_hint": "\(sourceHint)"
+            }
+          ]
+        }
+        """.utf8))
+    }
+}
+
+@MainActor
+private func makePagingViewModel(
+    database: DatabaseService,
+    pageSize: Int
+) -> (MessageView.ViewModel, MessageViewModelMockTransport) {
+    let transport = MessageViewModelMockTransport()
+    let client = PennyWebSocketClient(
+        databaseService: database,
+        prefs: configuredPrefs(),
+        webSocketClient: transport
+    )
+    return (MessageView.ViewModel(client: client, messagePageSize: pageSize), transport)
+}
+
+private func saveFilterFixture(in database: DatabaseService) {
+    database.save(message: testMessage(id: 1, content: "Penny", sourceHint: "Penny"))
+    database.save(message: testMessage(id: 2, content: "Startup", sourceHint: "Startup"))
+    database.save(message: testMessage(id: 3, content: "Schedule", sourceHint: "Schedule"))
+    database.save(message: testMessage(id: 4, content: "Chat", sourceHint: "Chat"))
+    database.save(message: testMessage(id: 5, content: "Test Push", sourceHint: "Test Push"))
+    database.save(message: testMessage(id: 6, content: "Notifier", sourceHint: "Notifier"))
+    database.save(message: testMessage(id: 7, content: "Collector", sourceHint: "Collector: flight-deals"))
+    database.save(message: testMessage(id: 8, serverID: nil, content: "Outgoing", isOutgoing: true))
+}
+
+private func saveNumberedMessages(in database: DatabaseService, ids: ClosedRange<Int>) {
+    for id in ids {
+        database.save(message: testMessage(id: id, content: "Message \(id)"))
+    }
+}
+
+private func testMessage(
+    id: Int,
+    serverID: Int? = nil,
+    content: String,
+    sourceHint: String? = nil,
+    isOutgoing: Bool = false
+) -> MessageModel {
+    MessageModel(
+        id: id,
+        serverID: serverID ?? (isOutgoing ? nil : id),
+        createdAt: Date(timeIntervalSince1970: TimeInterval(id)),
+        content: content,
+        sourceHint: sourceHint,
+        imageAttachmentDataURLs: [],
+        isOutgoing: isOutgoing
+    )
 }

--- a/penny-client/PennyClientTests/MessageViewModelTests.swift
+++ b/penny-client/PennyClientTests/MessageViewModelTests.swift
@@ -12,20 +12,6 @@ struct MessageViewModelTests {
         #expect(viewModel.selectedMessageLayout == .message)
     }
 
-    @Test func messageSelectionDefaultsToNil() {
-        let viewModel = MessageView.ViewModel(client: PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs()))
-
-        #expect(viewModel.selectedMessageID == nil)
-    }
-
-    @Test func messageSelectionCanBeUpdated() {
-        let viewModel = MessageView.ViewModel(client: PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs()))
-
-        viewModel.selectedMessageID = 42
-
-        #expect(viewModel.selectedMessageID == 42)
-    }
-
     @Test func messageLayoutCanSwitchBetweenAvailableLayouts() {
         let viewModel = MessageView.ViewModel(client: PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs()))
 

--- a/penny-client/PennyClientTests/PennyWebSocketClientTests.swift
+++ b/penny-client/PennyClientTests/PennyWebSocketClientTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 @testable import PennyClient
 
@@ -49,6 +50,98 @@ struct PennyWebSocketClientTests {
         #expect(database.loadMessages().first?.content == "hello Penny")
     }
 
+    @Test func initializationDoesNotLoadSavedMessagesIntoMemory() async {
+        let database = configuredDatabase()
+        database.save(message: MessageModel(id: 1, serverID: 1, createdAt: Date(timeIntervalSince1970: 1), content: "Saved", sourceHint: "Chat", imageAttachmentDataURLs: [], isOutgoing: false))
+        let client = PennyWebSocketClient(databaseService: database, prefs: configuredPrefs())
+
+        let page = await client.requestMessagePage(MessagePageRequest(limit: 20, filter: .all))
+
+        #expect(client.messages.isEmpty)
+        #expect(page.messages.map(\.content) == ["Saved"])
+    }
+
+    @Test func sendMessagePublishesToBoundMessages() {
+        let database = configuredDatabase()
+        let client = PennyWebSocketClient(databaseService: database, prefs: configuredPrefs())
+        var liveMessages: [ChatMessage] = []
+        var hasNewMessages = false
+        client.bindLiveMessages(
+            Binding(get: { liveMessages }, set: { liveMessages = $0 }),
+            hasNewMessages: Binding(get: { hasNewMessages }, set: { hasNewMessages = $0 }),
+            filter: .all
+        )
+
+        client.sendMessage("hello Penny")
+
+        #expect(liveMessages.map(\.content) == ["hello Penny"])
+        #expect(hasNewMessages == false)
+        #expect(database.loadMessages().first?.content == "hello Penny")
+    }
+
+    @Test func receivedMessagesPersistAckDedupeAndPublishLiveMessages() async {
+        let database = configuredDatabase()
+        let transport = MessagePagingMockTransport()
+        let client = PennyWebSocketClient(databaseService: database, prefs: configuredPrefs(), webSocketClient: transport)
+        var liveMessages: [ChatMessage] = []
+        var hasNewMessages = false
+        client.bindLiveMessages(
+            Binding(get: { liveMessages }, set: { liveMessages = $0 }),
+            hasNewMessages: Binding(get: { hasNewMessages }, set: { hasNewMessages = $0 }),
+            filter: .chat
+        )
+        await client.connect()
+        _ = await sentPayloads(transport, count: 2)
+        transport.clearSentPayloads()
+
+        transport.emit("""
+        {
+          "type": "messages",
+          "messages": [
+            {
+              "id": 11,
+              "created_at": "2026-07-05T00:00:00Z",
+              "content": "Visible chat",
+              "source_hint": "Chat"
+            },
+            {
+              "id": 12,
+              "created_at": "2026-07-05T00:00:01Z",
+              "content": "Filtered schedule",
+              "source_hint": "Schedule"
+            }
+          ]
+        }
+        """)
+        let payloads = await sentPayloads(transport, count: 1)
+
+        #expect(liveMessages.map(\.content) == ["Visible chat"])
+        #expect(hasNewMessages)
+        #expect(database.containsMessage(serverID: 11))
+        #expect(database.containsMessage(serverID: 12))
+        #expect(payloads.last?["type"] == .string("ack_messages"))
+        #expect(payloads.last?["ids"] == .array([.number(11), .number(12)]))
+
+        transport.clearSentPayloads()
+        transport.emit("""
+        {
+          "type": "messages",
+          "messages": [
+            {
+              "id": 11,
+              "created_at": "2026-07-05T00:00:00Z",
+              "content": "Visible chat duplicate",
+              "source_hint": "Chat"
+            }
+          ]
+        }
+        """)
+        _ = await sentPayloads(transport, count: 1)
+
+        #expect(liveMessages.map(\.content) == ["Visible chat"])
+        #expect(database.loadMessages().filter { $0.serverID == 11 }.count == 1)
+    }
+
     @Test func connectionStatusReflectsState() {
         let client = PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs())
 
@@ -79,4 +172,55 @@ struct PennyWebSocketClientTests {
         #expect(client.isTyping == false)
         #expect(client.canSend == false)
     }
+}
+
+@MainActor
+private final class MessagePagingMockTransport: WebSocketTransport {
+    private(set) var sentPayloads: [[String: JSONValue]] = []
+    private var onReceive: WebSocketTransport.ReceiveHandler?
+    private var onFailure: WebSocketTransport.FailureHandler?
+    var isConnected = false
+
+    func connect(
+        request: URLRequest,
+        onReceive: @escaping WebSocketTransport.ReceiveHandler,
+        onFailure: @escaping WebSocketTransport.FailureHandler
+    ) {
+        self.onReceive = onReceive
+        self.onFailure = onFailure
+        isConnected = true
+    }
+
+    func disconnect() {
+        onReceive = nil
+        onFailure = nil
+        isConnected = false
+    }
+
+    func send(_ data: Data) async throws {
+        sentPayloads.append(try JSONDecoder().decode([String: JSONValue].self, from: data))
+    }
+
+    func emit(_ json: String) {
+        onReceive?(Data(json.utf8))
+    }
+
+    func clearSentPayloads() {
+        sentPayloads.removeAll()
+    }
+}
+
+@MainActor
+private func sentPayloads(
+    _ transport: MessagePagingMockTransport,
+    count: Int
+) async -> [[String: JSONValue]] {
+    for _ in 0..<100 {
+        if transport.sentPayloads.count >= count {
+            return transport.sentPayloads
+        }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    #expect(transport.sentPayloads.count >= count)
+    return transport.sentPayloads
 }


### PR DESCRIPTION
- Refactors the chat screen into separate message/card scroll experiences, with card tap opening a detail sheet instead of selecting/highlighting inline.
- Adds paginated message loading from SQLite, including cursor-based older-message fetches, filter-aware pages, duplicate prevention by server ID, and live message binding for new arrivals.
- Smooths scroll/keyboard behavior: safer bottom scrolling, delayed keyboard-settle scroll, loading older messages without losing position, and cleaner layout switching.

Tests were expanded around message paging, filtering, live updates, duplicate handling, and websocket/database behavior.