### PR TITLE
codex fix what claude told us to break

### DIFF
--- a/penny-client/AGENTS.md
+++ b/penny-client/AGENTS.md
@@ -4,6 +4,9 @@
 PennyClient is a SwiftUI iOS chat client that connects to the Penny websocket service. The main app entry point and chat UI live in `PennyClient/PennyClient/Views/MessageView.swift`, with screen state and actions in `PennyClient/PennyClient/Views/MessageView+ViewModel.swift`.
 Use Xcode project-relative paths when working from Xcode tooling. Prefer Xcode tools for reading, editing, diagnostics, and builds.
 
+## Roadmap
+The current roadmap is tracked in https://github.com/lockhart-ai/penny/issues/1496. Check that issue for current priorities before making broad product or architectural changes.
+
 ## Important Files
 - `PennyClient/PennyClient/Views/MessageView.swift`: Main chat screen, toolbar, composer, message rows.
 - `PennyClient/PennyClient/Views/MessageView+ViewModel.swift`: Message screen view model.

--- a/penny-client/PennyClient.xcodeproj/project.pbxproj
+++ b/penny-client/PennyClient.xcodeproj/project.pbxproj
@@ -145,7 +145,6 @@
 				D1F83D862FF9A0000010DBDD /* Sources */,
 				D1F83D842FF9A0000010DBDD /* Frameworks */,
 				D1F83D872FF9A0000010DBDD /* Resources */,
-				D1F83D8B2FF9A0000010DBDD /* Inject Build Commit Hash */,
 			);
 			buildRules = (
 			);
@@ -231,28 +230,6 @@
 			);
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		D1F83D8B2FF9A0000010DBDD /* Inject Build Commit Hash */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Inject Build Commit Hash";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\ncommit=\"${GIT_COMMIT:-}\"\nplist_path=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nif [ -z \"$commit\" ]; then\n    /usr/libexec/PlistBuddy -c \"Delete :PennyBuildCommitHash\" \"$plist_path\" 2>/dev/null || true\n    exit 0\nfi\n\n/usr/libexec/PlistBuddy -c \"Set :PennyBuildCommitHash $commit\" \"$plist_path\" 2>/dev/null || \\\n    /usr/libexec/PlistBuddy -c \"Add :PennyBuildCommitHash string $commit\" \"$plist_path\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		000000000000000120000000 /* Sources */ = {
@@ -621,6 +598,7 @@
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				INFOPLIST_KEY_PennyBuildCommitHash = "$(GIT_COMMIT)";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UILaunchStoryboardName = "";
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
@@ -681,6 +659,7 @@
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				INFOPLIST_KEY_PennyBuildCommitHash = "$(GIT_COMMIT)";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UILaunchStoryboardName = "";
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;


### PR DESCRIPTION
Implemented the fix in [project.pbxproj](/Users/robertwaltham/Library/CloudStorage/Dropbox/penny/penny-client/PennyClient.xcodeproj/project.pbxproj:598).

What changed:
- Removed the `Inject Build Commit Hash` shell script phase from the `PennyTestflight` target.
- Added `INFOPLIST_KEY_PennyBuildCommitHash = "$(GIT_COMMIT)";` to the TestFlight target’s Debug and Release settings.

Verification:
- `plutil -lint` passes for the Xcode project.
- No remaining references to the removed script phase.
- `xcodebuild -showBuildSettings GIT_COMMIT=b7fd2759` resolves `INFOPLIST_KEY_PennyBuildCommitHash = b7fd2759`, so the existing CI `PlistBuddy` assertion should now read the generated key instead of depending on a sandbox-blocked script mutation.