### PR TITLE
move memory management to it's own menu

### DIFF
--- a/penny-client/PennyClient/Views/MemoryManagementView.swift
+++ b/penny-client/PennyClient/Views/MemoryManagementView.swift
@@ -7,6 +7,7 @@ struct MemoryManagementView: View {
     @State private var editedInclusion: MemoryInclusion = .relevant
     @State private var editedRecall: MemoryRecall = .recent
     @State private var editedPublished = false
+    @State private var isShowingCreateMemory = false
 
     init(client: PennyWebSocketClient) {
         _viewModel = State(initialValue: MemoryManagementViewModel(client: client))
@@ -14,46 +15,6 @@ struct MemoryManagementView: View {
 
     var body: some View {
         Form {
-            Section("Find") {
-                TextField("Search memories", text: $viewModel.query)
-                Button {
-                    viewModel.refresh()
-                } label: {
-                    Label("Search", systemImage: "magnifyingglass")
-                }
-            }
-
-            Section("Create") {
-                TextField("Name", text: $viewModel.newName)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                TextField("Description", text: $viewModel.newDescription, axis: .vertical)
-                    .lineLimit(1...3)
-                TextField("Intent", text: $viewModel.newIntent, axis: .vertical)
-                    .lineLimit(1...3)
-                Picker("Inclusion", selection: $viewModel.newInclusion) {
-                    ForEach(MemoryInclusion.allCasesForUI, id: \.self) { inclusion in
-                        Text(inclusion.title).tag(inclusion)
-                    }
-                }
-                Picker("Recall", selection: $viewModel.newRecall) {
-                    ForEach(MemoryRecall.allCasesForUI, id: \.self) { recall in
-                        Text(recall.title).tag(recall)
-                    }
-                }
-                Toggle("Published", isOn: $viewModel.newPublished)
-                TextField("Extraction prompt", text: $viewModel.newExtractionPrompt, axis: .vertical)
-                    .lineLimit(1...4)
-                TextField("Collector interval seconds", text: $viewModel.newCollectorIntervalText)
-                    .keyboardType(.numberPad)
-                Button {
-                    viewModel.createMemory()
-                } label: {
-                    Label("Create", systemImage: "plus")
-                }
-                .disabled(!viewModel.canCreateMemory)
-            }
-
             Section("Memories") {
                 if viewModel.memories.isEmpty {
                     ContentUnavailableView("No Memories", systemImage: "tray")
@@ -176,18 +137,84 @@ struct MemoryManagementView: View {
         }
         .navigationTitle("Memory")
         .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $viewModel.query, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search memories")
+        .onSubmit(of: .search) {
+            viewModel.refresh()
+        }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    viewModel.refresh()
-                } label: {
-                    Image(systemName: "arrow.clockwise")
+                HStack(spacing: 14) {
+                    Button {
+                        isShowingCreateMemory = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityLabel("Add memory")
+
+                    Button {
+                        viewModel.refresh()
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                    .accessibilityLabel("Refresh memories")
                 }
-                .accessibilityLabel("Refresh memories")
             }
+        }
+        .sheet(isPresented: $isShowingCreateMemory) {
+            createMemorySheet
         }
         .task {
             viewModel.refresh()
+        }
+    }
+
+    private var createMemorySheet: some View {
+        NavigationStack {
+            Form {
+                Section("Memory") {
+                    TextField("Name", text: $viewModel.newName)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    TextField("Description", text: $viewModel.newDescription, axis: .vertical)
+                        .lineLimit(1...3)
+                    TextField("Intent", text: $viewModel.newIntent, axis: .vertical)
+                        .lineLimit(1...3)
+                    Picker("Inclusion", selection: $viewModel.newInclusion) {
+                        ForEach(MemoryInclusion.allCasesForUI, id: \.self) { inclusion in
+                            Text(inclusion.title).tag(inclusion)
+                        }
+                    }
+                    Picker("Recall", selection: $viewModel.newRecall) {
+                        ForEach(MemoryRecall.allCasesForUI, id: \.self) { recall in
+                            Text(recall.title).tag(recall)
+                        }
+                    }
+                    Toggle("Published", isOn: $viewModel.newPublished)
+                }
+
+                Section("Collection") {
+                    TextField("Extraction prompt", text: $viewModel.newExtractionPrompt, axis: .vertical)
+                        .lineLimit(1...4)
+                    TextField("Collector interval seconds", text: $viewModel.newCollectorIntervalText)
+                        .keyboardType(.numberPad)
+                }
+            }
+            .navigationTitle("Add Memory")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        isShowingCreateMemory = false
+                    }
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Create") {
+                        submitCreateMemory()
+                    }
+                    .disabled(!viewModel.canCreateMemory)
+                }
+            }
         }
     }
 
@@ -198,6 +225,11 @@ struct MemoryManagementView: View {
         editedInclusion = memory.inclusion
         editedRecall = memory.recall
         editedPublished = memory.published
+    }
+
+    private func submitCreateMemory() {
+        viewModel.createMemory()
+        isShowingCreateMemory = false
     }
 }
 

--- a/penny-client/PennyClient/Views/MessageView.swift
+++ b/penny-client/PennyClient/Views/MessageView.swift
@@ -12,6 +12,7 @@ struct MessageView: View {
     @State private var messageContextScale: CGFloat = 1
     @State private var shouldUseFastComposerScroll = false
     @State private var keyboardSettledScrollTask: Task<Void, Never>?
+    @State private var selectedPennyNavigation: PennyNavigationDestination?
     @FocusState private var isComposerFocused: Bool
 
     private var effectiveMessageLayout: MessageLayout {
@@ -42,6 +43,7 @@ struct MessageView: View {
                 ToolbarItem(placement: .topBarLeading) {
                     HStack(spacing: 8) {
                         messageFilterMenu
+                        pennyNavigationMenu
 
                         if viewModel.hasHiddenNewMessages {
                             hiddenNewMessagesButton
@@ -91,6 +93,9 @@ struct MessageView: View {
             }
             .sheet(isPresented: $viewModel.isShowingSettings) {
                 SettingsView(client: viewModel.client)
+            }
+            .navigationDestination(item: $selectedPennyNavigation) { destination in
+                pennyNavigationDestination(destination)
             }
             .sheet(item: $presentedCardMessage) { message in
                 MessageCardDetailSheet(message: message)
@@ -201,6 +206,37 @@ struct MessageView: View {
                     shouldSettleLayout: viewModel.shouldSettleScrollToBottom
                 )
             }
+        }
+    }
+
+    private var pennyNavigationMenu: some View {
+        Menu {
+            ForEach(PennyNavigationDestination.allCases) { destination in
+                Button {
+                    selectedPennyNavigation = destination
+                } label: {
+                    Label(destination.title, systemImage: destination.systemImage)
+                }
+            }
+        } label: {
+            Image(systemName: "memories")
+                .frame(width: 28, height: 28)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.borderless)
+        .foregroundStyle(.primary)
+        .accessibilityLabel("Penny navigation")
+    }
+
+    @ViewBuilder
+    private func pennyNavigationDestination(_ destination: PennyNavigationDestination) -> some View {
+        switch destination {
+        case .schedules:
+            SchedulesView(client: viewModel.client)
+        case .insights:
+            InsightsView(client: viewModel.client)
+        case .memories:
+            MemoryManagementView(client: viewModel.client)
         }
     }
 
@@ -455,11 +491,44 @@ struct MessageView: View {
             }
     }
 
-    private func refreshFeaturePreferences() {
+}
+
+private enum PennyNavigationDestination: String, CaseIterable, Identifiable {
+    case schedules
+    case insights
+    case memories
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .schedules:
+            return "Schedules"
+        case .insights:
+            return "Insights"
+        case .memories:
+            return "Memories"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .schedules:
+            return "calendar"
+        case .insights:
+            return "chart.bar.doc.horizontal"
+        case .memories:
+            return "tray.full"
+        }
+    }
+}
+
+private extension MessageView {
+    func refreshFeaturePreferences() {
         isMessageLayoutSwitcherEnabled = Prefs.shared.isMessageLayoutSwitcherEnabled
     }
 
-    private func handleComposerFocusChanged(_ isFocused: Bool) {
+    func handleComposerFocusChanged(_ isFocused: Bool) {
         guard isFocused else {
             shouldUseFastComposerScroll = false
             keyboardSettledScrollTask?.cancel()
@@ -470,7 +539,7 @@ struct MessageView: View {
         shouldUseFastComposerScroll = false
     }
 
-    private func scheduleScrollAfterKeyboardSettles(fast: Bool = false) {
+    func scheduleScrollAfterKeyboardSettles(fast: Bool = false) {
         keyboardSettledScrollTask?.cancel()
         keyboardSettledScrollTask = Task { @MainActor in
             try? await Task.sleep(for: fast ? .milliseconds(120) : .milliseconds(350))
@@ -479,7 +548,7 @@ struct MessageView: View {
         }
     }
 
-    private func changeMessageLayout(to layout: MessageLayout) {
+    func changeMessageLayout(to layout: MessageLayout) {
         guard viewModel.selectedMessageLayout != layout else { return }
         if layout != .message {
             isComposerFocused = false
@@ -494,7 +563,7 @@ struct MessageView: View {
         viewModel.requestScrollToBottom()
     }
 
-    private func scheduleScrollToBottom(
+    func scheduleScrollToBottom(
         with proxy: ScrollViewProxy,
         animated: Bool = true,
         shouldSettleLayout: Bool = true
@@ -512,7 +581,7 @@ struct MessageView: View {
         }
     }
 
-    private func scrollToBottom(
+    func scrollToBottom(
         with proxy: ScrollViewProxy,
         animated: Bool = true,
         enableOlderPaging: Bool = true
@@ -530,7 +599,7 @@ struct MessageView: View {
         }
     }
 
-    private func loadOlderMessages(with proxy: ScrollViewProxy) {
+    func loadOlderMessages(with proxy: ScrollViewProxy) {
         guard let anchorID = viewModel.reserveOlderMessageLoad() else { return }
         Task {
             guard await viewModel.loadReservedOlderMessages() else { return }
@@ -544,9 +613,6 @@ struct MessageView: View {
         }
     }
 
-}
-
-private extension MessageView {
     @ViewBuilder
     var messageActionOverlay: some View {
         if let context = activeMessageContext {

--- a/penny-client/PennyClient/Views/SettingsView.swift
+++ b/penny-client/PennyClient/Views/SettingsView.swift
@@ -17,26 +17,6 @@ struct SettingsView: View {
                     }
                 }
 
-                Section("Penny") {
-                    NavigationLink {
-                        SchedulesView(client: viewModel.client)
-                    } label: {
-                        Label("Schedules", systemImage: "calendar")
-                    }
-
-                    NavigationLink {
-                        InsightsView(client: viewModel.client)
-                    } label: {
-                        Label("Insights", systemImage: "chart.bar.doc.horizontal")
-                    }
-
-                    NavigationLink {
-                        MemoryManagementView(client: viewModel.client)
-                    } label: {
-                        Label("Memory Management", systemImage: "tray.full")
-                    }
-                }
-
                 Section("Status") {
                     LabeledContent("Connection", value: viewModel.client.statusText)
                     LabeledContent("Pending", value: "\(viewModel.client.pendingCount)")


### PR DESCRIPTION
Small ui refactor to move the state management to it's own menu

<img width="281" height="610" alt="B166B657-15F6-4D68-AFF8-9EA2965165A9_4_5005_c" src="https://github.com/user-attachments/assets/cfb117ea-ca91-4085-bb45-66577c12953f" />
<img width="281" height="610" alt="4299130B-6C64-47F5-9B9D-FD8A86314A8A_4_5005_c" src="https://github.com/user-attachments/assets/6c1cf2ad-eca9-4c1b-b6fb-9b5b7c4e5097" />
<img width="281" height="610" alt="3F40A86E-01E0-43BF-B61E-C8191293E423_4_5005_c" src="https://github.com/user-attachments/assets/474d7815-5fe5-4004-accb-c01b7654d965" />
