### PR TITLE
implement message history syncing for iOS client

### DIFF
--- a/penny-client/PennyClient.xcodeproj/project.pbxproj
+++ b/penny-client/PennyClient.xcodeproj/project.pbxproj
@@ -236,21 +236,22 @@
 		D1F83D8B2FF9A0000010DBDD /* Inject Build Commit Hash */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
 			name = "Inject Build Commit Hash";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\ncommit=\"${GIT_COMMIT:-}\"\nplist_path=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nif [ -z \"$commit\" ]; then\n    /usr/libexec/PlistBuddy -c \"Delete :PennyBuildCommitHash\" \"$plist_path\" 2>/dev/null || true\n    exit 0\nfi\n\n/usr/libexec/PlistBuddy -c \"Set :PennyBuildCommitHash $commit\" \"$plist_path\" 2>/dev/null || \\\n    /usr/libexec/PlistBuddy -c \"Add :PennyBuildCommitHash string $commit\" \"$plist_path\"\n";
+			shellScript = (
+				"set -eu",
+				"",
+				"commit=\"${GIT_COMMIT:-}\"",
+				"plist_path=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"",
+				"if [ -z \"$commit\" ]; then",
+				"    /usr/libexec/PlistBuddy -c \"Delete :PennyBuildCommitHash\" \"$plist_path\" 2>/dev/null || true",
+				"    exit 0",
+				"fi",
+				"",
+				"/usr/libexec/PlistBuddy -c \"Set :PennyBuildCommitHash $commit\" \"$plist_path\" 2>/dev/null || \\",
+				"    /usr/libexec/PlistBuddy -c \"Add :PennyBuildCommitHash string $commit\" \"$plist_path\"",
+				"",
+			);
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -616,13 +617,13 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				GIT_COMMIT = "";
 				INFOPLIST_KEY_CFBundleDisplayName = Penny;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UILaunchStoryboardName = "";
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
@@ -677,13 +678,13 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				GIT_COMMIT = "";
 				INFOPLIST_KEY_CFBundleDisplayName = Penny;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
-				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UILaunchStoryboardName = "";
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;

--- a/penny-client/PennyClient/Service/DatabaseService.swift
+++ b/penny-client/PennyClient/Service/DatabaseService.swift
@@ -63,6 +63,22 @@ final class DatabaseService {
             }
             databaseConnection.userVersion = 2
         }
+
+        if currentVersion < 3 {
+            if try !MessageModel.columnExists(database: databaseConnection, name: "channel_type") {
+                try databaseConnection.run(MessageModel.table().addColumn(MessageModel.channelTypeExp))
+            }
+            if try !MessageModel.columnExists(database: databaseConnection, name: "device_label") {
+                try databaseConnection.run(MessageModel.table().addColumn(MessageModel.deviceLabelExp))
+            }
+            if try !MessageModel.columnExists(database: databaseConnection, name: "device_identifier") {
+                try databaseConnection.run(MessageModel.table().addColumn(MessageModel.deviceIdentifierExp))
+            }
+            if try !MessageModel.columnExists(database: databaseConnection, name: "parent_id") {
+                try databaseConnection.run(MessageModel.table().addColumn(MessageModel.parentIDExp))
+            }
+            databaseConnection.userVersion = 3
+        }
     }
 }
 
@@ -117,11 +133,54 @@ extension DatabaseService {
         }
     }
 
+    @discardableResult
+    func reconcileLegacyMessage(outboxID: Int, canonicalID: Int) -> Bool {
+        setup()
+
+        do {
+            return try MessageModel.reconcileLegacyMessage(
+                database: databaseConnection,
+                outboxID: outboxID,
+                canonicalID: canonicalID
+            )
+        } catch {
+            print(error)
+            return false
+        }
+    }
+
+    @discardableResult
+    func reconcileLocalMessage(content: String, createdAt: Date, canonicalID: Int) -> Int? {
+        setup()
+
+        do {
+            return try MessageModel.reconcileLocalMessage(
+                database: databaseConnection,
+                content: content,
+                createdAt: createdAt,
+                canonicalID: canonicalID
+            )
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+
     func save(message: MessageModel) {
         setup()
 
         do {
             try message.save(database: databaseConnection)
+        } catch {
+            print(error)
+        }
+    }
+
+    func deleteAllMessages() {
+        setup()
+
+        do {
+            try databaseConnection.run(MessageModel.table().delete())
         } catch {
             print(error)
         }
@@ -135,16 +194,36 @@ struct MessageModel: Codable, Identifiable, Hashable {
         createdAt = message.createdAt
         content = message.content
         sourceHint = message.sourceHint
+        channelType = message.channelType
+        deviceLabel = message.deviceLabel
+        deviceIdentifier = message.deviceIdentifier
+        parentID = message.parentID
         imageAttachmentDataURLs = message.imageAttachmentDataURLs
         isOutgoing = message.isOutgoing
     }
 
-    init(id: Int, serverID: Int?, createdAt: Date, content: String, sourceHint: String?, imageAttachmentDataURLs: [String], isOutgoing: Bool) {
+    init(
+        id: Int,
+        serverID: Int?,
+        createdAt: Date,
+        content: String,
+        sourceHint: String?,
+        channelType: String? = nil,
+        deviceLabel: String? = nil,
+        deviceIdentifier: String? = nil,
+        parentID: Int? = nil,
+        imageAttachmentDataURLs: [String],
+        isOutgoing: Bool
+    ) {
         self.id = id
         self.serverID = serverID
         self.createdAt = createdAt
         self.content = content
         self.sourceHint = sourceHint
+        self.channelType = channelType
+        self.deviceLabel = deviceLabel
+        self.deviceIdentifier = deviceIdentifier
+        self.parentID = parentID
         self.imageAttachmentDataURLs = imageAttachmentDataURLs
         self.isOutgoing = isOutgoing
     }
@@ -159,6 +238,14 @@ struct MessageModel: Codable, Identifiable, Hashable {
     var content: String
     @SqlProperty
     var sourceHint: String?
+    @SqlProperty
+    var channelType: String?
+    @SqlProperty
+    var deviceLabel: String?
+    @SqlProperty
+    var deviceIdentifier: String?
+    @SqlProperty
+    var parentID: Int?
     var imageAttachmentDataURLs: [String]
     fileprivate static var imageAttachmentDataURLsExp: SQLite.Expression<String> {
         Expression<String>("image_attachment_data_urls")
@@ -192,6 +279,10 @@ struct MessageModel: Codable, Identifiable, Hashable {
                 MessageModel.createdAtExp <- createdAt,
                 MessageModel.contentExp <- content,
                 MessageModel.sourceHintExp <- sourceHint,
+                MessageModel.channelTypeExp <- channelType,
+                MessageModel.deviceLabelExp <- deviceLabel,
+                MessageModel.deviceIdentifierExp <- deviceIdentifier,
+                MessageModel.parentIDExp <- parentID,
                 MessageModel.imageAttachmentDataURLsExp <- MessageModel.encodedImageAttachmentDataURLs(imageAttachmentDataURLs),
                 MessageModel.isOutgoingExp <- isOutgoing
             )
@@ -237,6 +328,59 @@ struct MessageModel: Codable, Identifiable, Hashable {
         try database.scalar(table().filter(serverIDExp == serverID).count) > 0
     }
 
+    fileprivate static func reconcileLegacyMessage(
+        database: Connection,
+        outboxID: Int,
+        canonicalID: Int
+    ) throws -> Bool {
+        guard outboxID != canonicalID,
+              let legacy = try database.pluck(table().filter(serverIDExp == outboxID)) else {
+            return false
+        }
+
+        let legacyID = legacy[idExp]
+        if let canonical = try database.pluck(table().filter(serverIDExp == canonicalID)) {
+            guard canonical[idExp] != legacyID else { return false }
+            try database.run(table().filter(idExp == legacyID).delete())
+            return true
+        }
+
+        try database.run(
+            table()
+                .filter(idExp == legacyID)
+                .update(idExp <- canonicalID, serverIDExp <- canonicalID)
+        )
+        return true
+    }
+
+    fileprivate static func reconcileLocalMessage(
+        database: Connection,
+        content: String,
+        createdAt: Date,
+        canonicalID: Int
+    ) throws -> Int? {
+        let candidates = try load(database: database).filter {
+            $0.serverID == nil && $0.id < 0 && $0.isOutgoing && $0.content == content
+        }
+        guard let local = candidates.min(by: {
+            abs($0.createdAt.timeIntervalSince(createdAt)) < abs($1.createdAt.timeIntervalSince(createdAt))
+        }) else {
+            return nil
+        }
+
+        if let canonical = try database.pluck(table().filter(serverIDExp == canonicalID)) {
+            guard canonical[idExp] != local.id else { return nil }
+            try database.run(table().filter(idExp == local.id).delete())
+        } else {
+            try database.run(
+                table()
+                    .filter(idExp == local.id)
+                    .update(idExp <- canonicalID, serverIDExp <- canonicalID)
+            )
+        }
+        return local.id
+    }
+
     private static func filteredTable(for filter: MessagePageFilter) -> Table {
         switch filter {
         case .all:
@@ -261,6 +405,10 @@ struct MessageModel: Codable, Identifiable, Hashable {
             createdAt: entry[createdAtExp],
             content: entry[contentExp],
             sourceHint: entry[sourceHintExp],
+            channelType: entry[channelTypeExp],
+            deviceLabel: entry[deviceLabelExp],
+            deviceIdentifier: entry[deviceIdentifierExp],
+            parentID: entry[parentIDExp],
             imageAttachmentDataURLs: decodedImageAttachmentDataURLs(entry[imageAttachmentDataURLsExp]),
             isOutgoing: entry[isOutgoingExp]
         )

--- a/penny-client/PennyClient/Service/DeviceIdentity.swift
+++ b/penny-client/PennyClient/Service/DeviceIdentity.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum DeviceIdentity {
+    private static let keychain = SystemKeychain()
+    private static let deviceIDAccount = "device_id"
+    private static let deviceSecretAccount = "device_secret"
+
+    static func stableDeviceID() -> String {
+        stableUUID(account: deviceIDAccount)
+    }
+
+    static func deviceSecret() -> String {
+        stableUUID(account: deviceSecretAccount)
+    }
+
+    private static func stableUUID(account: String) -> String {
+        if let existingValue = keychain.string(account: account) {
+            return existingValue
+        }
+
+        let newValue = UUID().uuidString
+        keychain.set(newValue, account: account)
+        return newValue
+    }
+}

--- a/penny-client/PennyClient/Service/PennyService+MessageSync.swift
+++ b/penny-client/PennyClient/Service/PennyService+MessageSync.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftUI
+import UserNotifications
+
+extension PennyService {
+    func replaceOptimisticMessage(localID: Int, with message: ChatMessage) {
+        if let index = messages.firstIndex(where: { $0.id == localID }) {
+            messages[index] = message
+            messages.sort {
+                $0.createdAt < $1.createdAt || ($0.createdAt == $1.createdAt && $0.id < $1.id)
+            }
+        }
+
+        guard var displayedMessages = liveMessages?.wrappedValue,
+              let index = displayedMessages.firstIndex(where: { $0.id == localID }) else { return }
+        displayedMessages[index] = message
+        displayedMessages.sort {
+            $0.createdAt < $1.createdAt || ($0.createdAt == $1.createdAt && $0.id < $1.id)
+        }
+        liveMessages?.wrappedValue = displayedMessages
+    }
+
+    func clearAppBadge() {
+        UNUserNotificationCenter.current().setBadgeCount(0) { error in
+            if let error {
+                print("Failed to clear badge count: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/penny-client/PennyClient/Service/PennyService.swift
+++ b/penny-client/PennyClient/Service/PennyService.swift
@@ -33,6 +33,16 @@ struct MessagePage {
     let hasMore: Bool
 }
 
+private struct HistoryPageResult {
+    let payload: MessagesPayload
+    let newMessageCount: Int
+}
+
+private enum HistorySyncEvent {
+    case page(HistoryPageResult)
+    case error(String)
+}
+
 enum MessagePageFilter: Equatable, Sendable {
     case all
     case penny
@@ -90,9 +100,13 @@ final class PennyService {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
-    @ObservationIgnored private var liveMessages: Binding<[ChatMessage]>?
+    @ObservationIgnored var liveMessages: Binding<[ChatMessage]>?
     @ObservationIgnored private var liveHasNewMessages: Binding<Bool>?
+    @ObservationIgnored private var historicalMessagesHandler: (([ChatMessage]) -> Void)?
     @ObservationIgnored private var liveMessageFilter: MessagePageFilter = .all
+    @ObservationIgnored private var historySyncTask: Task<Void, Never>?
+    @ObservationIgnored private var historyResponseContinuation: AsyncStream<HistorySyncEvent>.Continuation?
+    @ObservationIgnored private var historyPageIsNewest = false
 
     var messages: [ChatMessage] = []
     var pendingCount = 0
@@ -112,6 +126,9 @@ final class PennyService {
     var collectionTriggerResult: CollectionTriggerResult?
     var domainPermissions: [DomainPermissionEntry] = []
     var permissionPrompt: PermissionPrompt?
+    var historySyncing = false
+    var historySyncedCount = 0
+    var historyStatus = "Not started"
 
     private let pendingMessagePullLimit = 3
 
@@ -177,7 +194,8 @@ final class PennyService {
         if isConnected { return .orange }
         return .red
     }
-
+}
+extension PennyService {
     func connect() async {
         guard !webSocketClient.isConnected else { return }
 
@@ -210,6 +228,10 @@ final class PennyService {
 
     private func disconnect(clearLiveBindings: Bool) {
         stopBackgroundTasks()
+        historyResponseContinuation?.finish()
+        historyResponseContinuation = nil
+        historySyncTask?.cancel()
+        historySyncTask = nil
         if clearLiveBindings {
             unbindLiveMessages()
         }
@@ -235,20 +257,53 @@ final class PennyService {
     func bindLiveMessages(
         _ messages: Binding<[ChatMessage]>,
         hasNewMessages: Binding<Bool>,
-        filter: MessagePageFilter
+        filter: MessagePageFilter,
+        historicalMessages: (([ChatMessage]) -> Void)? = nil
     ) {
         liveMessages = messages
         liveHasNewMessages = hasNewMessages
         liveMessageFilter = filter
+        historicalMessagesHandler = historicalMessages
     }
 
     func updateLiveMessageFilter(_ filter: MessagePageFilter) {
         liveMessageFilter = filter
     }
 
+    func startHistorySync(channelTypes: [String]) {
+        guard !channelTypes.isEmpty else {
+            historyStatus = "Select at least one channel"
+            return
+        }
+        guard !historySyncing else { return }
+
+        historySyncTask?.cancel()
+        historySyncedCount = 0
+        historyStatus = "Starting..."
+        historySyncing = true
+        historySyncTask = Task { [weak self] in
+            await self?.crawlHistory(channelTypes: channelTypes)
+        }
+    }
+
+    func deleteAllMessages() {
+        historyResponseContinuation?.finish()
+        historyResponseContinuation = nil
+        historySyncTask?.cancel()
+        historySyncTask = nil
+        historySyncing = false
+        historySyncedCount = 0
+        historyStatus = "Not started"
+        databaseService.deleteAllMessages()
+        messages.removeAll()
+        liveMessages?.wrappedValue = []
+        liveHasNewMessages?.wrappedValue = false
+    }
+
     func unbindLiveMessages() {
         liveMessages = nil
         liveHasNewMessages = nil
+        historicalMessagesHandler = nil
     }
 
     func sendMessage(_ content: String) {
@@ -418,7 +473,9 @@ final class PennyService {
         request.setValue("Basic \(encodedCredentials)", forHTTPHeaderField: "Authorization")
         return request
     }
+}
 
+extension PennyService {
     private func startBackgroundTasks() {
         stopBackgroundTasks()
         heartbeatTask = Task { [weak self] in
@@ -483,6 +540,9 @@ final class PennyService {
         case .status(let payload):
             isConnected = payload.connected
             lastError = payload.error
+            if historySyncing, let error = payload.error {
+                historyResponseContinuation?.yield(.error(error))
+            }
         case .registered(let payload):
             isConnected = true
             isRegistered = true
@@ -494,7 +554,21 @@ final class PennyService {
                 send(.pullMessages(limit: pendingMessagePullLimit))
             }
         case .messages(let payload):
-            receive(payload.messages)
+            let newMessages = receive(payload)
+            if payload.mode == "history" {
+                if historyPageIsNewest {
+                    let visibleMessages = newMessages.filter { liveMessageFilter.includes($0) }
+                    if let historicalMessagesHandler {
+                        historicalMessagesHandler(visibleMessages)
+                    } else {
+                        publishLiveMessages(visibleMessages)
+                    }
+                }
+                historyResponseContinuation?.yield(.page(HistoryPageResult(
+                    payload: payload,
+                    newMessageCount: newMessages.count
+                )))
+            }
         case .messagesAcked:
             break
         case .typing(let payload):
@@ -565,30 +639,109 @@ final class PennyService {
         promptLogRuns[index].runReason = payload.reason
     }
 
-    private func receive(_ incomingMessages: [ServerChatMessage]) {
+    @discardableResult
+    private func receive(_ payload: MessagesPayload) -> [ChatMessage] {
+        // Deduplicate repeated canonical IDs before updating persistence or UI.
+        var seenMessageIDs = Set<Int>()
+        let incomingMessages = payload.messages.filter { seenMessageIDs.insert($0.canonicalID).inserted }
         let incomingIDs = incomingMessages.map(\.id)
         if incomingIDs.isEmpty {
-            pendingCount = 0
-            return
+            if payload.mode == "outbox" {
+                pendingCount = 0
+            }
+            return []
         }
 
-        let newMessages = incomingMessages
-            .filter { !databaseService.containsMessage(serverID: $0.id) }
-            .map(ChatMessage.remote)
+        incomingMessages.forEach { message in
+            guard let messageID = message.messageID,
+                  let outboxID = message.outboxID else { return }
+            databaseService.reconcileLegacyMessage(
+                outboxID: outboxID,
+                canonicalID: messageID
+            )
+        }
+
+        let decodedMessages = incomingMessages.map(ChatMessage.remote)
+        for message in decodedMessages where message.isOutgoing {
+            guard let localID = databaseService.reconcileLocalMessage(
+                content: message.content,
+                createdAt: message.createdAt,
+                canonicalID: message.id
+            ) else { continue }
+            replaceOptimisticMessage(localID: localID, with: message)
+        }
+        let newMessages = decodedMessages.filter {
+            !databaseService.containsMessage(serverID: $0.id)
+        }
+
+        // Persist the canonical representation, including metadata corrections.
+        decodedMessages.forEach { databaseService.save(message: MessageModel(message: $0)) }
 
         if !newMessages.isEmpty {
-            newMessages.forEach { databaseService.save(message: MessageModel(message: $0)) }
             messages.append(contentsOf: newMessages)
             messages.sort { $0.createdAt < $1.createdAt }
-            publishLiveMessages(newMessages)
         }
 
-        send(.ackMessages(ids: incomingIDs))
-        pendingCount = max(0, pendingCount - incomingIDs.count)
-        clearAppBadge()
+        if payload.mode == "outbox" {
+            publishLiveMessages(decodedMessages)
+            send(.ackMessages(ids: incomingIDs))
+            pendingCount = max(0, pendingCount - incomingIDs.count)
+            clearAppBadge()
+        }
 
         if pendingCount > 0 {
             send(.pullMessages(limit: pendingMessagePullLimit))
+        }
+        return newMessages
+    }
+}
+
+extension PennyService {
+    private func crawlHistory(channelTypes: [String]) async {
+        let stream = AsyncStream<HistorySyncEvent> { continuation in
+            historyResponseContinuation = continuation
+        }
+        var iterator = stream.makeAsyncIterator()
+        var cursor: String?
+
+        defer {
+            historyResponseContinuation?.finish()
+            historyResponseContinuation = nil
+            historySyncTask = nil
+            if historySyncing {
+                historySyncing = false
+            }
+        }
+
+        while !Task.isCancelled {
+            guard isConnected, isRegistered else {
+                historyStatus = "Waiting for connection"
+                return
+            }
+
+            historyPageIsNewest = cursor == nil
+            send(.historyRequest(limit: 30, before: cursor, channelTypes: channelTypes))
+            guard let event = await iterator.next() else { return }
+            guard case .page(let result) = event else {
+                if case .error(let error) = event {
+                    historyStatus = "Sync failed: \(error)"
+                }
+                return
+            }
+
+            historySyncedCount += result.newMessageCount
+            historyStatus = "Synced \(historySyncedCount) messages"
+            guard result.payload.hasMore, let nextCursor = result.payload.nextCursor else {
+                historyStatus = "Complete: \(historySyncedCount) messages synced"
+                return
+            }
+            cursor = nextCursor
+
+            do {
+                try await Task.sleep(for: .milliseconds(250))
+            } catch {
+                return
+            }
         }
     }
 
@@ -597,19 +750,18 @@ final class PennyService {
 
         let visibleMessages = newMessages.filter { liveMessageFilter.includes($0) }
         if !visibleMessages.isEmpty {
-            liveMessages?.wrappedValue.append(contentsOf: visibleMessages)
+            var mergedMessages = liveMessages?.wrappedValue ?? []
+            for message in visibleMessages where !mergedMessages.contains(where: { $0.id == message.id }) {
+                mergedMessages.append(message)
+            }
+            mergedMessages.sort {
+                $0.createdAt < $1.createdAt || ($0.createdAt == $1.createdAt && $0.id < $1.id)
+            }
+            liveMessages?.wrappedValue = mergedMessages
         }
 
         if visibleMessages.count != newMessages.count {
             liveHasNewMessages?.wrappedValue = true
-        }
-    }
-
-    private func clearAppBadge() {
-        UNUserNotificationCenter.current().setBadgeCount(0) { error in
-            if let error {
-                print("Failed to clear badge count: \(error.localizedDescription)")
-            }
         }
     }
 
@@ -648,6 +800,7 @@ private enum ClientMessage: Encodable {
     case register(RegisterPayload)
     case message(content: String)
     case pullMessages(limit: Int)
+    case historyRequest(limit: Int, before: String?, channelTypes: [String]?)
     case ackMessages(ids: [Int])
     case heartbeat
     case configRequest
@@ -711,6 +864,11 @@ private enum ClientMessage: Encodable {
         case .pullMessages(let limit):
             try container.encode("pull_messages", forKey: .type)
             try container.encode(limit, forKey: .limit)
+        case .historyRequest(let limit, let before, let channelTypes):
+            try container.encode("history_request", forKey: .type)
+            try container.encode(limit, forKey: .limit)
+            try container.encodeIfPresent(before, forKey: .before)
+            try container.encodeIfPresent(channelTypes, forKey: .channelTypes)
         case .ackMessages(let ids):
             try container.encode("ack_messages", forKey: .type)
             try container.encode(ids, forKey: .ids)
@@ -845,6 +1003,8 @@ private enum ClientMessage: Encodable {
         case appVersion = "app_version"
         case content
         case limit
+        case before
+        case channelTypes = "channel_types"
         case ids
         case key
         case value
@@ -1061,6 +1221,24 @@ private struct OutboxChangedPayload: Decodable {
 
 private struct MessagesPayload: Decodable {
     let messages: [ServerChatMessage]
+    let mode: String
+    let nextCursor: String?
+    let hasMore: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case messages
+        case mode
+        case nextCursor = "next_cursor"
+        case hasMore = "has_more"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        messages = try container.decode([ServerChatMessage].self, forKey: .messages)
+        mode = try container.decodeIfPresent(String.self, forKey: .mode) ?? "outbox"
+        nextCursor = try container.decodeIfPresent(String.self, forKey: .nextCursor)
+        hasMore = try container.decodeIfPresent(Bool.self, forKey: .hasMore) ?? false
+    }
 }
 
 private struct MessagesAckedPayload: Decodable {
@@ -1573,6 +1751,15 @@ private struct ServerChatMessage: Decodable {
     let sourceHint: String?
     let pushTitle: String?
     let pushSummary: String?
+    let messageID: Int?
+    let outboxID: Int?
+    let direction: String?
+    let channelType: String?
+    let deviceLabel: String?
+    let deviceIdentifier: String?
+    let parentID: Int?
+
+    var canonicalID: Int { messageID ?? id }
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -1584,6 +1771,13 @@ private struct ServerChatMessage: Decodable {
         case sourceHint = "source_hint"
         case pushTitle = "push_title"
         case pushSummary = "push_summary"
+        case messageID = "message_id"
+        case outboxID = "outbox_id"
+        case direction
+        case channelType = "channel_type"
+        case deviceLabel = "device_label"
+        case deviceIdentifier = "device_identifier"
+        case parentID = "parent_id"
     }
 
     init(from decoder: Decoder) throws {
@@ -1596,6 +1790,13 @@ private struct ServerChatMessage: Decodable {
         sourceHint = try container.decodeIfPresent(String.self, forKey: .sourceHint)
         pushTitle = try container.decodeIfPresent(String.self, forKey: .pushTitle)
         pushSummary = try container.decodeIfPresent(String.self, forKey: .pushSummary)
+        messageID = try container.decodeIfPresent(Int.self, forKey: .messageID)
+        outboxID = try container.decodeIfPresent(Int.self, forKey: .outboxID)
+        direction = try container.decodeIfPresent(String.self, forKey: .direction)
+        channelType = try container.decodeIfPresent(String.self, forKey: .channelType)
+        deviceLabel = try container.decodeIfPresent(String.self, forKey: .deviceLabel)
+        deviceIdentifier = try container.decodeIfPresent(String.self, forKey: .deviceIdentifier)
+        parentID = try container.decodeIfPresent(Int.self, forKey: .parentID)
 
         let createdAtString = try container.decode(String.self, forKey: .createdAt)
         createdAt = DateParser.parse(createdAtString) ?? .now
@@ -1648,6 +1849,10 @@ struct ChatMessage: Identifiable {
     let createdAt: Date
     let content: String
     let sourceHint: String?
+    let channelType: String?
+    let deviceLabel: String?
+    let deviceIdentifier: String?
+    let parentID: Int?
     let imageAttachmentDataURLs: [String]
     let imageAttachments: [ImageAttachment]
     let isOutgoing: Bool
@@ -1662,6 +1867,10 @@ struct ChatMessage: Identifiable {
         createdAt: Date,
         content: String,
         sourceHint: String?,
+        channelType: String? = nil,
+        deviceLabel: String? = nil,
+        deviceIdentifier: String? = nil,
+        parentID: Int? = nil,
         imageAttachmentDataURLs: [String] = [],
         imageAttachments: [ImageAttachment],
         isOutgoing: Bool
@@ -1671,6 +1880,10 @@ struct ChatMessage: Identifiable {
         self.createdAt = createdAt
         self.content = content
         self.sourceHint = sourceHint
+        self.channelType = channelType
+        self.deviceLabel = deviceLabel
+        self.deviceIdentifier = deviceIdentifier
+        self.parentID = parentID
         self.imageAttachmentDataURLs = imageAttachmentDataURLs
         self.imageAttachments = imageAttachments
         self.isOutgoing = isOutgoing
@@ -1682,6 +1895,10 @@ struct ChatMessage: Identifiable {
         createdAt = model.createdAt
         content = model.content
         sourceHint = model.sourceHint
+        channelType = model.channelType
+        deviceLabel = model.deviceLabel
+        deviceIdentifier = model.deviceIdentifier
+        parentID = model.parentID
         imageAttachmentDataURLs = model.imageAttachmentDataURLs
         imageAttachments = model.imageAttachmentDataURLs.compactMap { dataURL in
             guard let data = DataURLDecoder.decode(dataURL), let image = UIImage(data: data) else { return nil }
@@ -1698,14 +1915,18 @@ struct ChatMessage: Identifiable {
         let imageAttachmentDataURLs = message.attachments.compactMap(\.dataURL)
         let imageAttachments = message.attachments.compactMap(\.image).map(ImageAttachment.init(image:))
         return ChatMessage(
-            id: message.id,
-            serverID: message.id,
+            id: message.canonicalID,
+            serverID: message.canonicalID,
             createdAt: message.createdAt,
             content: message.content,
             sourceHint: message.sourceHint,
+            channelType: message.channelType,
+            deviceLabel: message.deviceLabel,
+            deviceIdentifier: message.deviceIdentifier,
+            parentID: message.parentID,
             imageAttachmentDataURLs: imageAttachmentDataURLs,
             imageAttachments: imageAttachments,
-            isOutgoing: false
+            isOutgoing: message.direction == "incoming"
         )
     }
 }
@@ -1772,28 +1993,4 @@ private enum DateParser {
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
         return formatter
     }()
-}
-
-private enum DeviceIdentity {
-    private static let keychain = SystemKeychain()
-    private static let deviceIDAccount = "device_id"
-    private static let deviceSecretAccount = "device_secret"
-
-    static func stableDeviceID() -> String {
-        stableUUID(account: deviceIDAccount)
-    }
-
-    static func deviceSecret() -> String {
-        stableUUID(account: deviceSecretAccount)
-    }
-
-    private static func stableUUID(account: String) -> String {
-        if let existingValue = keychain.string(account: account) {
-            return existingValue
-        }
-
-        let newValue = UUID().uuidString
-        keychain.set(newValue, account: account)
-        return newValue
-    }
 }

--- a/penny-client/PennyClient/Views/AdminFeatureViewModels.swift
+++ b/penny-client/PennyClient/Views/AdminFeatureViewModels.swift
@@ -338,6 +338,14 @@ final class SettingsViewModel {
         client.deleteDomain(domain: entry.domain)
     }
 
+    func startHistorySync(channelTypes: [String]) {
+        client.startHistorySync(channelTypes: channelTypes)
+    }
+
+    func deleteAllMessages() {
+        client.deleteAllMessages()
+    }
+
     func decidePermissionPrompt(allowed: Bool) {
         guard let prompt = permissionPrompt else { return }
         client.decidePermission(requestID: prompt.requestID, allowed: allowed)

--- a/penny-client/PennyClient/Views/MessageView+ViewModel.swift
+++ b/penny-client/PennyClient/Views/MessageView+ViewModel.swift
@@ -346,9 +346,39 @@ extension MessageView {
                     get: { [weak self] in self?.hasHiddenNewMessages ?? false },
                     set: { [weak self] hasNewMessages in self?.hasHiddenNewMessages = hasNewMessages }
                 ),
-                filter: selectedMessageFilter.pageFilter
+                filter: selectedMessageFilter.pageFilter,
+                historicalMessages: { [weak self] messages in
+                    self?.mergeNewestHistoricalMessages(messages)
+                }
             )
             hasBoundLiveMessages = true
+        }
+
+        private func mergeNewestHistoricalMessages(_ incomingMessages: [ChatMessage]) {
+            guard !incomingMessages.isEmpty else { return }
+
+            let existingIDs = Set(displayedMessages.map(\.id))
+            let candidates = incomingMessages.filter { !existingIDs.contains($0.id) }
+            guard !candidates.isEmpty else { return }
+
+            guard let newest = displayedMessages.last else {
+                replaceDisplayedMessages(with: candidates.sorted { $0.createdAt < $1.createdAt })
+                scrollToBottomRequest += 1
+                return
+            }
+
+            let newestMessages = candidates.filter {
+                $0.createdAt > newest.createdAt || ($0.createdAt == newest.createdAt && $0.id > newest.id)
+            }
+            guard !newestMessages.isEmpty else { return }
+
+            suppressDisplayedMessageChanges = true
+            displayedMessages.append(contentsOf: newestMessages)
+            displayedMessages.sort {
+                $0.createdAt < $1.createdAt || ($0.createdAt == $1.createdAt && $0.id < $1.id)
+            }
+            suppressDisplayedMessageChanges = false
+            scrollToBottomRequest += 1
         }
 
         private func replaceDisplayedMessages(with messages: [ChatMessage]) {

--- a/penny-client/PennyClient/Views/SettingsView.swift
+++ b/penny-client/PennyClient/Views/SettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var viewModel: SettingsViewModel
+    @State private var selectedHistoryChannels = Set(HistoryChannel.allCases.map(\.rawValue))
+    @State private var isShowingDeleteMessagesConfirmation = false
 
     init(client: PennyWebSocketClient) {
         _viewModel = State(initialValue: SettingsViewModel(client: client, prefs: .shared))
@@ -42,6 +44,49 @@ struct SettingsView: View {
                 Section("Features") {
                     Toggle("1-2-3 layout", isOn: $viewModel.isMessageLayoutSwitcherEnabled)
                 }
+
+                Section("History") {
+                    ForEach(HistoryChannel.allCases) { channel in
+                        Toggle(channel.title, isOn: Binding(
+                            get: { selectedHistoryChannels.contains(channel.rawValue) },
+                            set: { isSelected in
+                                if isSelected {
+                                    selectedHistoryChannels.insert(channel.rawValue)
+                                } else {
+                                    selectedHistoryChannels.remove(channel.rawValue)
+                                }
+                            }
+                        ))
+                        .disabled(viewModel.client.historySyncing)
+                    }
+
+                    LabeledContent("Messages synced", value: "\(viewModel.client.historySyncedCount)")
+                    Text(viewModel.client.historyStatus)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Button {
+                        viewModel.startHistorySync(channelTypes: Array(selectedHistoryChannels).sorted())
+                    } label: {
+                        Label(
+                            viewModel.client.historySyncing ? "Syncing History" : "Sync History",
+                            systemImage: viewModel.client.historySyncing
+                                ? "arrow.triangle.2.circlepath"
+                                : "clock.arrow.circlepath"
+                        )
+                    }
+                    .disabled(selectedHistoryChannels.isEmpty || viewModel.client.historySyncing)
+                }
+
+                #if DEBUG
+                Section("Developer") {
+                    Button(role: .destructive) {
+                        isShowingDeleteMessagesConfirmation = true
+                    } label: {
+                        Label("Delete All Local Messages", systemImage: "trash")
+                    }
+                }
+                #endif
 
                 if let prompt = viewModel.permissionPrompt {
                     Section("Permission Request") {
@@ -136,6 +181,19 @@ struct SettingsView: View {
             .task {
                 viewModel.refresh()
             }
+            #if DEBUG
+            .confirmationDialog(
+                "Delete all local messages?",
+                isPresented: $isShowingDeleteMessagesConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Delete All Messages", role: .destructive) {
+                    viewModel.deleteAllMessages()
+                }
+            } message: {
+                Text("This removes every message stored on this device. It does not delete messages from the server.")
+            }
+            #endif
         }
     }
 
@@ -207,6 +265,28 @@ private extension DomainPermission {
             return "Allowed"
         case .blocked:
             return "Blocked"
+        }
+    }
+}
+
+private enum HistoryChannel: String, CaseIterable, Identifiable {
+    case ios
+    case signal
+    case discord
+    case browser
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .ios:
+            return "iOS"
+        case .signal:
+            return "Signal"
+        case .discord:
+            return "Discord"
+        case .browser:
+            return "Browser"
         }
     }
 }

--- a/penny-client/PennyClientTests/ChatMessageContentParserTests.swift
+++ b/penny-client/PennyClientTests/ChatMessageContentParserTests.swift
@@ -111,7 +111,9 @@ struct ChatMessageContentParserTests {
 
         let replyContent = ChatReplyContentParser.parse(content)
 
-        #expect(replyContent == ChatReplyContent(body: "Hacks", author: "You", summary: "/console ffxglow 0"))
+        #expect(replyContent?.body == "Hacks")
+        #expect(replyContent?.author == "You")
+        #expect(replyContent?.summary == "/console ffxglow 0")
     }
 
     @Test func ignoresContentWithoutReplyContext() {

--- a/penny-client/PennyClientTests/DatabaseServiceTests.swift
+++ b/penny-client/PennyClientTests/DatabaseServiceTests.swift
@@ -43,6 +43,19 @@ struct DatabaseServiceTests {
         #expect(loaded.map(\.content) == ["First", "Second"])
     }
 
+    @Test func deletesAllMessagesWithoutRemovingTheDatabase() {
+        let database = DatabaseService()
+        database.setupForTesting()
+        database.save(message: makeMessage(id: 1, content: "First"))
+        database.save(message: makeMessage(id: 2, content: "Second"))
+
+        database.deleteAllMessages()
+
+        #expect(database.loadMessages().isEmpty)
+        database.save(message: makeMessage(id: 3, content: "Still usable"))
+        #expect(database.loadMessages().map(\.content) == ["Still usable"])
+    }
+
     @Test func latestMessagePageReturnsNewestMessagesInDisplayOrder() {
         let database = DatabaseService()
         database.setupForTesting()
@@ -98,6 +111,29 @@ struct DatabaseServiceTests {
         #expect(database.minimumMessageID() == -3)
         #expect(database.containsMessage(serverID: 10))
         #expect(database.containsMessage(serverID: 11) == false)
+    }
+
+    @Test func reconcilesLegacyOutboxServerIDToCanonicalMessageID() {
+        let database = DatabaseService()
+        database.setupForTesting()
+        database.save(message: makeMessage(id: 17, serverID: 17, content: "Legacy"))
+
+        #expect(database.reconcileLegacyMessage(outboxID: 17, canonicalID: 42))
+        let loaded = database.loadMessages()
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.id == 42)
+        #expect(loaded.first?.serverID == 42)
+    }
+
+    @Test func removesLegacyRowWhenCanonicalMessageAlreadyExists() {
+        let database = DatabaseService()
+        database.setupForTesting()
+        database.save(message: makeMessage(id: 17, serverID: 17, content: "Legacy"))
+        database.save(message: makeMessage(id: 42, serverID: 42, content: "Canonical"))
+
+        #expect(database.reconcileLegacyMessage(outboxID: 17, canonicalID: 42))
+        let loaded = database.loadMessages()
+        #expect(loaded.map(\.content) == ["Canonical"])
     }
 }
 

--- a/penny-client/PennyClientTests/PennyWebSocketClientTests.swift
+++ b/penny-client/PennyClientTests/PennyWebSocketClientTests.swift
@@ -142,6 +142,187 @@ struct PennyWebSocketClientTests {
         #expect(database.loadMessages().filter { $0.serverID == 11 }.count == 1)
     }
 
+    @Test func duplicateMessagesInOnePayloadBecomeOnePersistedAndDisplayedMessage() async {
+        let database = configuredDatabase()
+        let transport = MessagePagingMockTransport()
+        let client = PennyWebSocketClient(
+            databaseService: database,
+            prefs: configuredPrefs(),
+            webSocketClient: transport
+        )
+        var liveMessages: [ChatMessage] = []
+        var hasNewMessages = false
+        client.bindLiveMessages(
+            Binding(get: { liveMessages }, set: { liveMessages = $0 }),
+            hasNewMessages: Binding(get: { hasNewMessages }, set: { hasNewMessages = $0 }),
+            filter: .all
+        )
+
+        await client.connect()
+        transport.clearSentPayloads()
+        transport.emit("""
+        {
+          "type": "messages",
+          "messages": [
+            {
+              "id": 41,
+              "created_at": "2026-07-05T00:00:01Z",
+              "content": "Penny response",
+              "source_hint": "Penny"
+            },
+            {
+              "id": 41,
+              "created_at": "2026-07-05T00:00:01Z",
+              "content": "Penny response duplicate",
+              "source_hint": "Penny"
+            }
+          ]
+        }
+        """)
+
+        #expect(liveMessages.map(\.id) == [41])
+        #expect(database.loadMessages().filter { $0.serverID == 41 }.count == 1)
+        #expect(client.messages.map(\.id) == [41])
+        #expect(hasNewMessages == false)
+    }
+
+    @Test func historyReconcilesLocallyStoredOutgoingMessage() async {
+        let database = configuredDatabase()
+        let transport = MessagePagingMockTransport()
+        let client = PennyWebSocketClient(
+            databaseService: database,
+            prefs: configuredPrefs(),
+            webSocketClient: transport
+        )
+        var liveMessages: [ChatMessage] = []
+        var hasNewMessages = false
+        client.bindLiveMessages(
+            Binding(get: { liveMessages }, set: { liveMessages = $0 }),
+            hasNewMessages: Binding(get: { hasNewMessages }, set: { hasNewMessages = $0 }),
+            filter: .all
+        )
+        await client.connect()
+        client.sendMessage("hi")
+        #expect(liveMessages.map(\.id) == [-1])
+
+        transport.emit("""
+        {
+          "type": "messages",
+          "mode": "history",
+          "messages": [
+            {
+              "id": 51,
+              "created_at": "2026-07-05T00:00:01Z",
+              "content": "hi",
+              "direction": "incoming",
+              "source_hint": "Chat"
+            }
+          ]
+        }
+        """)
+
+        #expect(liveMessages.map(\.id) == [51])
+        #expect(client.messages.map(\.id) == [51])
+        #expect(database.loadMessages().map(\.id) == [51])
+        #expect(hasNewMessages == false)
+    }
+
+    @Test func outboxDeliveryPublishesMessageAlreadyPersistedByHistory() async {
+        let database = configuredDatabase()
+        database.save(message: MessageModel(
+            id: 21,
+            serverID: 21,
+            createdAt: Date(timeIntervalSince1970: 21),
+            content: "Historical message",
+            sourceHint: "Penny",
+            imageAttachmentDataURLs: [],
+            isOutgoing: false
+        ))
+        let transport = MessagePagingMockTransport()
+        let client = PennyWebSocketClient(
+            databaseService: database,
+            prefs: configuredPrefs(),
+            webSocketClient: transport
+        )
+        var liveMessages: [ChatMessage] = []
+        var hasNewMessages = false
+        client.bindLiveMessages(
+            Binding(get: { liveMessages }, set: { liveMessages = $0 }),
+            hasNewMessages: Binding(get: { hasNewMessages }, set: { hasNewMessages = $0 }),
+            filter: .all
+        )
+
+        await client.connect()
+        _ = await sentPayloads(transport, count: 2)
+        transport.emit("""
+        {
+          "type": "messages",
+          "messages": [
+            {
+              "id": 7,
+              "message_id": 21,
+              "outbox_id": 7,
+              "created_at": "2026-07-05T00:00:00Z",
+              "content": "Historical message",
+              "source_hint": "Penny"
+            }
+          ]
+        }
+        """)
+
+        _ = await sentPayloads(transport, count: 1)
+        // Keep the assertion focused on the live binding rather than persistence.
+        #expect(liveMessages.map(\.content) == ["Historical message"])
+        #expect(hasNewMessages == false)
+    }
+
+    @Test func historyMarksUserSentMessagesAsOutgoing() async {
+        let database = configuredDatabase()
+        let transport = MessagePagingMockTransport()
+        let client = PennyWebSocketClient(
+            databaseService: database,
+            prefs: configuredPrefs(),
+            webSocketClient: transport
+        )
+        var liveMessages: [ChatMessage] = []
+        var hasNewMessages = false
+        client.bindLiveMessages(
+            Binding(get: { liveMessages }, set: { liveMessages = $0 }),
+            hasNewMessages: Binding(get: { hasNewMessages }, set: { hasNewMessages = $0 }),
+            filter: .all
+        )
+        await client.connect()
+        transport.clearSentPayloads()
+        client.isConnected = true
+        client.isRegistered = true
+        client.startHistorySync(channelTypes: ["ios"])
+        _ = await sentPayloads(transport, count: 1)
+
+        transport.emit("""
+        {
+          "type": "messages",
+          "mode": "history",
+          "has_more": false,
+          "messages": [
+            {
+              "id": 31,
+              "message_id": 31,
+              "created_at": "2026-07-05T00:00:00Z",
+              "content": "Message from me",
+              "direction": "incoming",
+              "source_hint": "Chat"
+            }
+          ]
+        }
+        """)
+
+        try? await Task.sleep(for: .milliseconds(20))
+
+        #expect(liveMessages.first?.isOutgoing == true)
+        #expect(database.loadMessages().first?.isOutgoing == true)
+        #expect(hasNewMessages == false)
+    }
+
     @Test func connectionStatusReflectsState() {
         let client = PennyWebSocketClient(databaseService: configuredDatabase(), prefs: configuredPrefs())
 

--- a/penny/penny/channels/base.py
+++ b/penny/penny/channels/base.py
@@ -166,6 +166,7 @@ class MessageChannel(ABC):
         attachments: list[str] | None = None,
         quote_message: MessageLog | None = None,
         source_name: str | None = None,
+        message_log_id: int | None = None,
     ) -> int | None:
         """
         Deliver an already-prepared message to the platform.
@@ -182,7 +183,8 @@ class MessageChannel(ABC):
             message: Message content (already prepared via prepare_outgoing)
             attachments: Optional list of base64-encoded attachments
             quote_message: Optional message to quote-reply to
-            source_name: Optional source attribution for durable channels
+        source_name: Optional source attribution for durable channels
+            message_log_id: Canonical messagelog ID for channels with durable delivery metadata
 
         Returns:
             Platform message id / timestamp on success, None on failure
@@ -397,7 +399,12 @@ class MessageChannel(ABC):
             embedding=serialize_embedding(embedding) if embedding is not None else None,
         )
         external_id = await self._send_raw(
-            recipient, prepared, attachments, quote_message, source_name
+            recipient,
+            prepared,
+            attachments,
+            quote_message,
+            source_name,
+            message_id,
         )
         # Store the external ID for future reactions and quote replies
         if external_id and message_id:

--- a/penny/penny/channels/browser/channel.py
+++ b/penny/penny/channels/browser/channel.py
@@ -1235,6 +1235,7 @@ class BrowserChannel(MessageChannel):
         attachments: list[str] | None = None,
         quote_message: MessageLog | None = None,
         source_name: str | None = None,
+        message_log_id: int | None = None,
     ) -> int | None:
         """Deliver a prepared message to a browser client by device label.
 

--- a/penny/penny/channels/discord/channel.py
+++ b/penny/penny/channels/discord/channel.py
@@ -215,6 +215,7 @@ class DiscordChannel(MessageChannel):
         attachments: list[str] | None = None,
         quote_message: MessageLog | None = None,
         source_name: str | None = None,
+        message_log_id: int | None = None,
     ) -> int | None:
         """
         Deliver a prepared message via Discord.

--- a/penny/penny/channels/ios/channel.py
+++ b/penny/penny/channels/ios/channel.py
@@ -120,7 +120,7 @@ if TYPE_CHECKING:
     from penny.agents.collector import Collector
     from penny.commands import CommandRegistry
     from penny.database import Database
-    from penny.database.models import IosOutboxItem, MessageLog
+    from penny.database.models import Device, IosOutboxItem, MessageLog
 
 logger = logging.getLogger(__name__)
 
@@ -1019,7 +1019,7 @@ class IosChannel(MessageChannel):
         if has_more and rows:
             oldest = rows[0]
             next_cursor = _encode_history_cursor(
-                oldest[0].timestamp, oldest[0].id or 0, request.channel_types
+                oldest[0].timestamp, _required_message_id(oldest[0]), request.channel_types
             )
         await self._send_ws(
             ws,
@@ -1222,7 +1222,7 @@ class IosChannel(MessageChannel):
 
 def _outbox_record(row: IosOutboxItem) -> IosOutboxRecord:
     return IosOutboxRecord(
-        id=row.id or 0,
+        id=_required_outbox_id(row),
         message_id=row.message_log_id,
         outbox_id=row.id,
         created_at=row.created_at.isoformat(),
@@ -1236,7 +1236,7 @@ def _outbox_record(row: IosOutboxItem) -> IosOutboxRecord:
     )
 
 
-def _history_record(row: tuple[MessageLog, object, IosOutboxItem | None]) -> IosOutboxRecord:
+def _history_record(row: tuple[MessageLog, Device | None, IosOutboxItem | None]) -> IosOutboxRecord:
     message, device, outbox = row
     if outbox is not None and (outbox.source_hint or outbox.source_name):
         source_type = outbox.source_type
@@ -1256,7 +1256,7 @@ def _history_record(row: tuple[MessageLog, object, IosOutboxItem | None]) -> Ios
         source_type = None
         source_name = None
     return IosOutboxRecord(
-        id=message.id or 0,
+        id=_required_message_id(message),
         message_id=message.id,
         outbox_id=outbox.id if outbox is not None else None,
         created_at=message.timestamp.isoformat(),
@@ -1268,9 +1268,9 @@ def _history_record(row: tuple[MessageLog, object, IosOutboxItem | None]) -> Ios
         push_title="",
         push_summary="",
         direction=message.direction,
-        channel_type=getattr(device, "channel_type", None),
-        device_label=getattr(device, "label", None),
-        device_identifier=getattr(device, "identifier", None),
+        channel_type=device.channel_type if device is not None else None,
+        device_label=device.label if device is not None else None,
+        device_identifier=device.identifier if device is not None else None,
         parent_id=message.parent_id,
     )
 
@@ -1295,7 +1295,7 @@ def _encode_history_cursor(
     payload = {
         "timestamp": timestamp.isoformat(),
         "id": message_id,
-        "channels": channel_types or [],
+        "channels": channel_types if channel_types is not None else [],
     }
     return base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
 
@@ -1307,12 +1307,25 @@ def _decode_history_cursor(
         return None
     try:
         payload = json.loads(base64.urlsafe_b64decode(value.encode()).decode())
-        if payload.get("channels", []) != (channel_types or []):
+        expected_channels = channel_types if channel_types is not None else []
+        if payload.get("channels", []) != expected_channels:
             raise ValueError("history cursor scope mismatch")
         timestamp = datetime.fromisoformat(payload["timestamp"])
         return timestamp.replace(tzinfo=None), int(payload["id"])
     except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise ValueError("invalid history cursor") from exc
+
+
+def _required_message_id(message: MessageLog) -> int:
+    if message.id is None:
+        raise ValueError("history message is missing its database ID")
+    return message.id
+
+
+def _required_outbox_id(row: IosOutboxItem) -> int:
+    if row.id is None:
+        raise ValueError("iOS outbox row is missing its database ID")
+    return row.id
 
 
 _PASSTHROUGH_SOURCE_NAMES = frozenset(

--- a/penny/penny/channels/ios/channel.py
+++ b/penny/penny/channels/ios/channel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import json
 import logging
@@ -81,10 +82,12 @@ from penny.channels.ios.apns import ApnsClient, ApnsError
 from penny.channels.ios.models import (
     IOS_MSG_TYPE_ACK,
     IOS_MSG_TYPE_HEARTBEAT,
+    IOS_MSG_TYPE_HISTORY,
     IOS_MSG_TYPE_MESSAGE,
     IOS_MSG_TYPE_PULL,
     IOS_MSG_TYPE_REGISTER,
     IosAckMessages,
+    IosHistoryRequest,
     IosIncomingMessage,
     IosMessages,
     IosMessagesAcked,
@@ -270,6 +273,8 @@ class IosChannel(MessageChannel):
             await self._handle_chat_message(data, device_identifier)
         elif msg_type == IOS_MSG_TYPE_PULL:
             await self._handle_pull(ws, data, device_identifier)
+        elif msg_type == IOS_MSG_TYPE_HISTORY:
+            await self._handle_history(ws, data, device_identifier)
         elif msg_type == IOS_MSG_TYPE_ACK:
             await self._handle_ack(ws, data, device_identifier)
         elif msg_type == IOS_MSG_TYPE_HEARTBEAT:
@@ -986,7 +991,45 @@ class IosChannel(MessageChannel):
             await self._send_ws(ws, IosStatus(error="register_required"))
             return
         rows = self._db.ios.pending_for_device(conn.device_id, limit=msg.limit)
-        await self._send_ws(ws, IosMessages(messages=[_outbox_record(row) for row in rows]))
+        await self._send_ws(
+            ws, IosMessages(messages=[_outbox_record(row) for row in rows], mode="outbox")
+        )
+
+    async def _handle_history(
+        self, ws: ServerConnection, data: dict, device_identifier: str
+    ) -> None:
+        """Return one bounded, older-first page from the shared message log."""
+        try:
+            request = IosHistoryRequest(**data)
+            cursor = _decode_history_cursor(request.before, request.channel_types)
+        except ValidationError, ValueError:
+            await self._send_ws(ws, IosStatus(error="invalid_history_request"))
+            return
+        if self._connections.get(device_identifier) is None:
+            await self._send_ws(ws, IosStatus(error="register_required"))
+            return
+
+        rows, has_more = self._db.messages.ios_history_page(
+            channel_types=request.channel_types,
+            before=cursor,
+            limit=request.limit,
+        )
+        records = [_history_record(row) for row in rows]
+        next_cursor = None
+        if has_more and rows:
+            oldest = rows[0]
+            next_cursor = _encode_history_cursor(
+                oldest[0].timestamp, oldest[0].id or 0, request.channel_types
+            )
+        await self._send_ws(
+            ws,
+            IosMessages(
+                messages=records,
+                mode="history",
+                next_cursor=next_cursor,
+                has_more=has_more,
+            ),
+        )
 
     async def _handle_ack(self, ws: ServerConnection, data: dict, device_identifier: str) -> None:
         """Acknowledge displayed/persisted outbox rows."""
@@ -1029,6 +1072,7 @@ class IosChannel(MessageChannel):
         attachments: list[str] | None = None,
         quote_message: MessageLog | None = None,
         source_name: str | None = None,
+        message_log_id: int | None = None,
     ) -> int | None:
         """Persist message to the iOS outbox and notify the app."""
         device = self._db.devices.get_by_identifier(recipient)
@@ -1041,6 +1085,7 @@ class IosChannel(MessageChannel):
             message=message,
             attachments=attachments,
             source_name=source_name,
+            message_log_id=message_log_id,
         )
         if item.id is None:
             return None
@@ -1075,6 +1120,7 @@ class IosChannel(MessageChannel):
     def _enqueue_ios_outbox_item(
         self,
         *,
+        message_log_id: int | None = None,
         device_id: int,
         message: str,
         attachments: list[str] | None,
@@ -1083,6 +1129,7 @@ class IosChannel(MessageChannel):
         source_type, source_hint = _source_metadata(source_name)
         push_title, push_summary = _push_preview(message)
         return self._db.ios.enqueue_outbox(
+            message_log_id=message_log_id,
             device_id=device_id,
             content=message,
             attachments=attachments,
@@ -1174,18 +1221,98 @@ class IosChannel(MessageChannel):
 
 
 def _outbox_record(row: IosOutboxItem) -> IosOutboxRecord:
-    attachments = json.loads(row.attachments_json) if row.attachments_json else []
     return IosOutboxRecord(
         id=row.id or 0,
+        message_id=row.message_log_id,
+        outbox_id=row.id,
         created_at=row.created_at.isoformat(),
         content=row.content,
-        attachments=attachments,
+        attachments=_decode_outbox_attachments(row),
         source_type=row.source_type,
         source_name=row.source_name,
         source_hint=row.source_hint,
         push_title=row.push_title,
         push_summary=row.push_summary,
     )
+
+
+def _history_record(row: tuple[MessageLog, object, IosOutboxItem | None]) -> IosOutboxRecord:
+    message, device, outbox = row
+    if outbox is not None and (outbox.source_hint or outbox.source_name):
+        source_type = outbox.source_type
+        source_name = outbox.source_name
+        _, derived_hint = _source_metadata(outbox.source_name)
+        source_hint = outbox.source_hint or derived_hint
+    elif message.direction == "incoming" or message.parent_id is not None:
+        source_hint = "Chat"
+        source_type = None
+        source_name = None
+    elif message.thought_id is not None:
+        source_hint = "Notifier"
+        source_type = "collector"
+        source_name = None
+    else:
+        source_hint = "Penny"
+        source_type = None
+        source_name = None
+    return IosOutboxRecord(
+        id=message.id or 0,
+        message_id=message.id,
+        outbox_id=outbox.id if outbox is not None else None,
+        created_at=message.timestamp.isoformat(),
+        content=message.content,
+        attachments=_decode_outbox_attachments(outbox) if outbox is not None else [],
+        source_type=source_type,
+        source_name=source_name,
+        source_hint=source_hint,
+        push_title="",
+        push_summary="",
+        direction=message.direction,
+        channel_type=getattr(device, "channel_type", None),
+        device_label=getattr(device, "label", None),
+        device_identifier=getattr(device, "identifier", None),
+        parent_id=message.parent_id,
+    )
+
+
+def _decode_outbox_attachments(row: IosOutboxItem) -> list[str]:
+    """Recover the inline attachment payload retained by an outbox row."""
+    if not row.attachments_json:
+        return []
+    try:
+        attachments = json.loads(row.attachments_json)
+    except TypeError, ValueError:
+        logger.warning("Ignoring malformed iOS outbox attachments (outbox_id=%s)", row.id)
+        return []
+    if not isinstance(attachments, list):
+        return []
+    return [attachment for attachment in attachments if isinstance(attachment, str)]
+
+
+def _encode_history_cursor(
+    timestamp: datetime, message_id: int, channel_types: list[str] | None
+) -> str:
+    payload = {
+        "timestamp": timestamp.isoformat(),
+        "id": message_id,
+        "channels": channel_types or [],
+    }
+    return base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+
+
+def _decode_history_cursor(
+    value: str | None, channel_types: list[str] | None
+) -> tuple[datetime, int] | None:
+    if value is None:
+        return None
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(value.encode()).decode())
+        if payload.get("channels", []) != (channel_types or []):
+            raise ValueError("history cursor scope mismatch")
+        timestamp = datetime.fromisoformat(payload["timestamp"])
+        return timestamp.replace(tzinfo=None), int(payload["id"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid history cursor") from exc
 
 
 _PASSTHROUGH_SOURCE_NAMES = frozenset(

--- a/penny/penny/channels/ios/models.py
+++ b/penny/penny/channels/ios/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 
 IOS_MSG_TYPE_ACK = "ack_messages"
 IOS_MSG_TYPE_HEARTBEAT = "heartbeat"
+IOS_MSG_TYPE_HISTORY = "history_request"
 IOS_MSG_TYPE_MESSAGE = "message"
 IOS_MSG_TYPE_PULL = "pull_messages"
 IOS_MSG_TYPE_REGISTER = "register"
@@ -45,6 +46,15 @@ class IosPullMessages(BaseModel):
     limit: int = Field(default=50, ge=1, le=200)
 
 
+class IosHistoryRequest(BaseModel):
+    """Request one older page from the shared message log."""
+
+    type: str = IOS_MSG_TYPE_HISTORY
+    limit: int = Field(default=50, ge=1, le=200)
+    before: str | None = None
+    channel_types: list[str] | None = None
+
+
 class IosAckMessages(BaseModel):
     """Acknowledge outbox rows after the app has persisted/displayed them."""
 
@@ -56,6 +66,8 @@ class IosOutboxRecord(BaseModel):
     """One outbox row returned to the app."""
 
     id: int
+    message_id: int | None = None
+    outbox_id: int | None = None
     created_at: str
     content: str
     attachments: list[str] = []
@@ -64,6 +76,11 @@ class IosOutboxRecord(BaseModel):
     source_hint: str | None = None
     push_title: str
     push_summary: str
+    direction: str | None = None
+    channel_type: str | None = None
+    device_label: str | None = None
+    device_identifier: str | None = None
+    parent_id: int | None = None
 
 
 class IosStatus(BaseModel):
@@ -84,10 +101,13 @@ class IosRegistered(BaseModel):
 
 
 class IosMessages(BaseModel):
-    """Outbox response."""
+    """Outbox or history response."""
 
     type: str = IOS_RESP_TYPE_MESSAGES
     messages: list[IosOutboxRecord]
+    mode: str = "outbox"
+    next_cursor: str | None = None
+    has_more: bool = False
 
 
 class IosMessagesAcked(BaseModel):

--- a/penny/penny/channels/ios/models.py
+++ b/penny/penny/channels/ios/models.py
@@ -70,7 +70,7 @@ class IosOutboxRecord(BaseModel):
     outbox_id: int | None = None
     created_at: str
     content: str
-    attachments: list[str] = []
+    attachments: list[str] = Field(default_factory=list)
     source_type: str | None = None
     source_name: str | None = None
     source_hint: str | None = None

--- a/penny/penny/channels/manager.py
+++ b/penny/penny/channels/manager.py
@@ -127,6 +127,7 @@ class ChannelManager(MessageChannel):
         attachments: list[str] | None = None,
         quote_message: MessageLog | None = None,
         source_name: str | None = None,
+        message_log_id: int | None = None,
     ) -> int | None:
         """Route a prepared message to the correct channel via device lookup.
 
@@ -136,7 +137,9 @@ class ChannelManager(MessageChannel):
         exactly once, not double-logged by the concrete channel.
         """
         channel = self._resolve_channel(recipient)
-        return await channel._send_raw(recipient, message, attachments, quote_message, source_name)
+        return await channel._send_raw(
+            recipient, message, attachments, quote_message, source_name, message_log_id
+        )
 
     async def send_typing(self, recipient: str, typing: bool) -> bool:
         """Route a typing indicator to the correct channel."""

--- a/penny/penny/channels/signal/channel.py
+++ b/penny/penny/channels/signal/channel.py
@@ -384,6 +384,7 @@ class SignalChannel(MessageChannel):
         attachments: list[str] | None = None,
         quote_message: MessageLog | None = None,
         source_name: str | None = None,
+        message_log_id: int | None = None,
     ) -> int | None:
         """Deliver a prepared message via the Signal REST API.
 

--- a/penny/penny/database/ios_store.py
+++ b/penny/penny/database/ios_store.py
@@ -67,6 +67,7 @@ class IosStore:
     def enqueue_outbox(
         self,
         *,
+        message_log_id: int | None = None,
         device_id: int,
         content: str,
         attachments: list[str] | None,
@@ -79,6 +80,7 @@ class IosStore:
         """Append a message to the durable iOS outbox."""
         with self._session() as session:
             row = IosOutboxItem(
+                message_log_id=message_log_id,
                 device_id=device_id,
                 content=content,
                 attachments_json=json.dumps(attachments) if attachments else None,

--- a/penny/penny/database/message_store.py
+++ b/penny/penny/database/message_store.py
@@ -464,6 +464,8 @@ class MessageStore:
         message-log rows may not have a populated ``device_id``.
         """
         with self._session() as session:
+            message_columns = MessageLog.__table__.c
+            outbox_columns = IosOutboxItem.__table__.c
             devices = list(session.exec(select(Device)).all())
             if channel_types:
                 devices = [device for device in devices if device.channel_type in channel_types]
@@ -473,21 +475,21 @@ class MessageStore:
             device_ids = [device.id for device in devices if device.id is not None]
             identifiers = [device.identifier for device in devices]
             scope = or_(
-                MessageLog.device_id.in_(device_ids),
-                MessageLog.sender.in_(identifiers),
-                MessageLog.recipient.in_(identifiers),
+                message_columns.device_id.in_(device_ids),
+                message_columns.sender.in_(identifiers),
+                message_columns.recipient.in_(identifiers),
             )
             query = (
                 select(MessageLog, Device)
                 .join(Device, isouter=True)
                 .where(
-                    MessageLog.direction.in_(
+                    message_columns.direction.in_(
                         [
                             PennyConstants.MessageDirection.INCOMING,
                             PennyConstants.MessageDirection.OUTGOING,
                         ]
                     ),
-                    MessageLog.is_reaction == False,  # noqa: E712
+                    message_columns.is_reaction.is_(False),
                     scope,
                 )
             )
@@ -495,15 +497,18 @@ class MessageStore:
                 timestamp, message_id = before
                 query = query.where(
                     or_(
-                        MessageLog.timestamp < timestamp,
-                        and_(MessageLog.timestamp == timestamp, MessageLog.id < message_id),
+                        message_columns.timestamp < timestamp,
+                        and_(
+                            message_columns.timestamp == timestamp,
+                            message_columns.id < message_id,
+                        ),
                     )
                 )
             rows = list(
                 session.exec(
-                    query.order_by(MessageLog.timestamp.desc(), MessageLog.id.desc()).limit(
-                        limit + 1
-                    )
+                    query.order_by(
+                        message_columns.timestamp.desc(), message_columns.id.desc()
+                    ).limit(limit + 1)
                 ).all()
             )
             has_more = len(rows) > limit
@@ -517,8 +522,8 @@ class MessageStore:
                 session.exec(
                     select(IosOutboxItem).where(
                         or_(
-                            IosOutboxItem.message_log_id.in_(message_ids),
-                            IosOutboxItem.id.in_(outbox_ids),
+                            outbox_columns.message_log_id.in_(message_ids),
+                            outbox_columns.id.in_(outbox_ids),
                         )
                     )
                 ).all()

--- a/penny/penny/database/message_store.py
+++ b/penny/penny/database/message_store.py
@@ -7,13 +7,20 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import Any, NamedTuple
 
-from sqlalchemy import bindparam, func, text
+from sqlalchemy import and_, bindparam, func, or_, text
 from sqlmodel import Session, select
 
 from penny.agents.models import MessageRole
 from penny.constants import PennyConstants, RunOutcome
 from penny.database.memory.objects import classify_run, render_run_record
-from penny.database.models import CommandLog, MemoryEntry, MessageLog, PromptLog
+from penny.database.models import (
+    CommandLog,
+    Device,
+    IosOutboxItem,
+    MemoryEntry,
+    MessageLog,
+    PromptLog,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -443,6 +450,99 @@ class MessageStore:
             all_messages = incoming + threaded + autonomous
             all_messages.sort(key=lambda m: m.timestamp)
             return all_messages[-limit:]
+
+    def ios_history_page(
+        self,
+        *,
+        channel_types: list[str] | None,
+        before: tuple[datetime, int] | None,
+        limit: int,
+    ) -> tuple[list[tuple[MessageLog, Device | None, IosOutboxItem | None]], bool]:
+        """Return one newest-first boundary page for the iOS history surface.
+
+        Device identifiers are used as a compatibility fallback because older
+        message-log rows may not have a populated ``device_id``.
+        """
+        with self._session() as session:
+            devices = list(session.exec(select(Device)).all())
+            if channel_types:
+                devices = [device for device in devices if device.channel_type in channel_types]
+            if not devices:
+                return [], False
+
+            device_ids = [device.id for device in devices if device.id is not None]
+            identifiers = [device.identifier for device in devices]
+            scope = or_(
+                MessageLog.device_id.in_(device_ids),
+                MessageLog.sender.in_(identifiers),
+                MessageLog.recipient.in_(identifiers),
+            )
+            query = (
+                select(MessageLog, Device)
+                .join(Device, isouter=True)
+                .where(
+                    MessageLog.direction.in_(
+                        [
+                            PennyConstants.MessageDirection.INCOMING,
+                            PennyConstants.MessageDirection.OUTGOING,
+                        ]
+                    ),
+                    MessageLog.is_reaction == False,  # noqa: E712
+                    scope,
+                )
+            )
+            if before is not None:
+                timestamp, message_id = before
+                query = query.where(
+                    or_(
+                        MessageLog.timestamp < timestamp,
+                        and_(MessageLog.timestamp == timestamp, MessageLog.id < message_id),
+                    )
+                )
+            rows = list(
+                session.exec(
+                    query.order_by(MessageLog.timestamp.desc(), MessageLog.id.desc()).limit(
+                        limit + 1
+                    )
+                ).all()
+            )
+            has_more = len(rows) > limit
+            ordered = list(reversed(rows[:limit]))
+            message_ids = [message.id for message, _ in ordered if message.id is not None]
+            outbox_ids = []
+            for message, _ in ordered:
+                if message.external_id and message.external_id.isdecimal():
+                    outbox_ids.append(int(message.external_id))
+            outbox_rows = list(
+                session.exec(
+                    select(IosOutboxItem).where(
+                        or_(
+                            IosOutboxItem.message_log_id.in_(message_ids),
+                            IosOutboxItem.id.in_(outbox_ids),
+                        )
+                    )
+                ).all()
+            )
+            outbox_by_message_id = {
+                row.message_log_id: row for row in outbox_rows if row.message_log_id is not None
+            }
+            outbox_by_id = {row.id: row for row in outbox_rows if row.id is not None}
+            resolved: list[tuple[MessageLog, Device | None, IosOutboxItem | None]] = []
+            for message, device in ordered:
+                if device is None:
+                    device = next(
+                        (
+                            candidate
+                            for candidate in devices
+                            if candidate.identifier in {message.sender, message.recipient}
+                        ),
+                        None,
+                    )
+                outbox = outbox_by_message_id.get(message.id)
+                if outbox is None and message.external_id and message.external_id.isdecimal():
+                    outbox = outbox_by_id.get(int(message.external_id))
+                resolved.append((message, device, outbox))
+            return resolved, has_more
 
     def get_unprocessed(self, sender: str, limit: int) -> list[MessageLog]:
         """Get recent unprocessed non-reaction messages from a specific user."""

--- a/penny/penny/database/migrations/0080_ios_outbox_message_log_link.py
+++ b/penny/penny/database/migrations/0080_ios_outbox_message_log_link.py
@@ -1,0 +1,47 @@
+"""Link iOS outbox rows to their canonical message-log records."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def up(conn: sqlite3.Connection) -> None:
+    tables = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    }
+    if not {"ios_outbox", "messagelog", "device"}.issubset(tables):
+        return
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(ios_outbox)").fetchall()}
+    if "message_log_id" not in columns:
+        conn.execute(
+            "ALTER TABLE ios_outbox ADD COLUMN message_log_id INTEGER REFERENCES messagelog(id)"
+        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS ix_ios_outbox_message_log_id ON ios_outbox (message_log_id)"
+    )
+    # Older iOS sends stored the outbox ID in messagelog.external_id. Recover
+    # that relationship before the client starts using message-log IDs for
+    # history deduplication.
+    conn.execute(
+        """
+        UPDATE ios_outbox
+        SET message_log_id = (
+            SELECT ml.id
+            FROM messagelog AS ml
+            WHERE ml.direction = 'outgoing'
+              AND ml.external_id = CAST(ios_outbox.id AS TEXT)
+              AND (
+                  ml.device_id = ios_outbox.device_id
+                  OR ml.recipient = (
+                      SELECT d.identifier FROM device AS d WHERE d.id = ios_outbox.device_id
+                  )
+              )
+            ORDER BY ml.id DESC
+            LIMIT 1
+        )
+        WHERE ios_outbox.message_log_id IS NULL
+        """
+    )
+    conn.commit()

--- a/penny/penny/database/migrations/0080_ios_outbox_message_log_link.py
+++ b/penny/penny/database/migrations/0080_ios_outbox_message_log_link.py
@@ -21,6 +21,18 @@ def up(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS ix_ios_outbox_message_log_id ON ios_outbox (message_log_id)"
     )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS ix_messagelog_device_timestamp_id "
+        "ON messagelog (device_id, timestamp, id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS ix_messagelog_sender_timestamp_id "
+        "ON messagelog (sender, timestamp, id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS ix_messagelog_recipient_timestamp_id "
+        "ON messagelog (recipient, timestamp, id)"
+    )
     # Older iOS sends stored the outbox ID in messagelog.external_id. Recover
     # that relationship before the client starts using message-log IDs for
     # history deduplication.

--- a/penny/penny/database/models.py
+++ b/penny/penny/database/models.py
@@ -347,6 +347,7 @@ class IosOutboxItem(SQLModel, table=True):
     __tablename__ = "ios_outbox"
 
     id: int | None = Field(default=None, primary_key=True)
+    message_log_id: int | None = Field(default=None, foreign_key="messagelog.id", index=True)
     device_id: int = Field(foreign_key="device.id", index=True)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), index=True)
     content: str

--- a/penny/penny/database/models.py
+++ b/penny/penny/database/models.py
@@ -3,6 +3,7 @@
 import json
 from datetime import UTC, datetime
 
+from sqlalchemy import Index
 from sqlmodel import Field, SQLModel
 
 
@@ -62,6 +63,12 @@ class MessageLog(SQLModel, table=True):
         default=None, foreign_key="device.id", index=True
     )  # FK to device that sent/received this message
     embedding: bytes | None = None  # Serialized float32 embedding vector
+
+    __table_args__ = (
+        Index("ix_messagelog_device_timestamp_id", "device_id", "timestamp", "id"),
+        Index("ix_messagelog_sender_timestamp_id", "sender", "timestamp", "id"),
+        Index("ix_messagelog_recipient_timestamp_id", "recipient", "timestamp", "id"),
+    )
 
 
 class UserInfo(SQLModel, table=True):

--- a/penny/penny/tests/channels/test_ios_channel.py
+++ b/penny/penny/tests/channels/test_ios_channel.py
@@ -15,6 +15,7 @@ from penny.channels.ios.apns import ApnsClient, ApnsConfig, ApnsEnvironment, Apn
 from penny.channels.ios.channel import PUSH_GREETING_TITLE, TEST_PUSH_MESSAGE, IosChannel
 from penny.channels.ios.models import (
     IOS_MSG_TYPE_ACK,
+    IOS_MSG_TYPE_HISTORY,
     IOS_MSG_TYPE_PULL,
     IOS_MSG_TYPE_REGISTER,
     IOS_RESP_TYPE_MESSAGES,
@@ -312,6 +313,172 @@ async def test_send_raw_queues_outbox_and_sends_push_preview_when_disconnected(t
     assert apns.sent[0]["body"] == "Found a fare drop."
     assert apns.sent[0]["badge"] == 1
     assert apns.sent[0]["environment"] == "sandbox"
+
+
+@pytest.mark.asyncio
+async def test_history_request_returns_cross_channel_page_without_ack(tmp_path):
+    db = _make_db(tmp_path)
+    channel = _make_channel(db)
+    ws = FakeWs()
+    await channel._handle_register(
+        cast(Any, ws),
+        {
+            "type": IOS_MSG_TYPE_REGISTER,
+            "device_id": "ios-keychain-id",
+            "label": "iPhone",
+            "pairing_token": "pair-me",
+        },
+    )
+    ios_device = db.devices.get_by_identifier("ios-keychain-id")
+    signal_device = db.devices.register("signal", "+15551234567", "Signal")
+    assert ios_device is not None and ios_device.id is not None
+    assert signal_device.id is not None
+
+    db.messages.log_message("incoming", "ios-keychain-id", "ios question", device_id=ios_device.id)
+    db.messages.log_message(
+        "outgoing", "penny", "signal reply", recipient="+15551234567", device_id=signal_device.id
+    )
+    db.messages.log_message(
+        "incoming", "+15551234567", "signal question", device_id=signal_device.id
+    )
+
+    await channel._handle_history(
+        cast(Any, ws),
+        {"type": IOS_MSG_TYPE_HISTORY, "limit": 2},
+        "ios-keychain-id",
+    )
+
+    response = ws.sent[-1]
+    assert response["type"] == IOS_RESP_TYPE_MESSAGES
+    assert response["mode"] == "history"
+    assert response["has_more"] is True
+    assert [message["content"] for message in response["messages"]] == [
+        "signal reply",
+        "signal question",
+    ]
+    assert response["messages"][-1]["source_hint"] == "Chat"
+    assert all("outbox_id" not in message for message in response["messages"])
+    assert not any(message["type"] == "ack_messages" for message in ws.sent)
+
+
+@pytest.mark.asyncio
+async def test_history_cursor_fetches_next_page_without_overlap(tmp_path):
+    db = _make_db(tmp_path)
+    channel = _make_channel(db)
+    ws = FakeWs()
+    await channel._handle_register(
+        cast(Any, ws),
+        {
+            "type": IOS_MSG_TYPE_REGISTER,
+            "device_id": "ios-keychain-id",
+            "label": "iPhone",
+            "pairing_token": "pair-me",
+        },
+    )
+    device = db.devices.get_by_identifier("ios-keychain-id")
+    assert device is not None and device.id is not None
+
+    for content in ["oldest", "middle", "newest"]:
+        db.messages.log_message("incoming", "ios-keychain-id", content, device_id=device.id)
+
+    await channel._handle_history(
+        cast(Any, ws),
+        {"type": IOS_MSG_TYPE_HISTORY, "limit": 2},
+        "ios-keychain-id",
+    )
+    first_page = ws.sent[-1]
+    assert [message["content"] for message in first_page["messages"]] == ["middle", "newest"]
+    assert first_page["has_more"] is True
+    assert first_page["next_cursor"] is not None
+
+    await channel._handle_history(
+        cast(Any, ws),
+        {"type": IOS_MSG_TYPE_HISTORY, "limit": 2, "before": first_page["next_cursor"]},
+        "ios-keychain-id",
+    )
+    second_page = ws.sent[-1]
+    assert [message["content"] for message in second_page["messages"]] == ["oldest"]
+    assert second_page["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_history_reconstructs_source_hint_from_ios_outbox(tmp_path):
+    db = _make_db(tmp_path)
+    channel = _make_channel(db)
+    ws = FakeWs()
+    await channel._handle_register(
+        cast(Any, ws),
+        {
+            "type": IOS_MSG_TYPE_REGISTER,
+            "device_id": "ios-keychain-id",
+            "label": "iPhone",
+            "pairing_token": "pair-me",
+        },
+    )
+    device = db.devices.get_by_identifier("ios-keychain-id")
+    assert device is not None and device.id is not None
+    message_id = db.messages.log_message(
+        "outgoing",
+        "penny",
+        "scheduled historical message",
+        recipient="ios-keychain-id",
+        device_id=device.id,
+    )
+    assert message_id is not None
+    db.ios.enqueue_outbox(
+        message_log_id=message_id,
+        device_id=device.id,
+        content="scheduled historical message",
+        attachments=["data:image/png;base64,aGVsbG8="],
+        source_type="schedule",
+        source_name="schedule",
+        source_hint="Schedule",
+        push_title="Hi from Penny",
+        push_summary="scheduled historical message",
+    )
+
+    await channel._handle_history(
+        cast(Any, ws),
+        {"type": IOS_MSG_TYPE_HISTORY, "limit": 10},
+        "ios-keychain-id",
+    )
+
+    record = next(
+        message
+        for message in ws.sent[-1]["messages"]
+        if message["content"] == "scheduled historical message"
+    )
+    assert record["source_hint"] == "Schedule"
+    assert record["source_name"] == "schedule"
+    assert record["outbox_id"] is not None
+    assert record["attachments"] == ["data:image/png;base64,aGVsbG8="]
+
+
+@pytest.mark.asyncio
+async def test_outbox_record_links_to_message_log_id(tmp_path):
+    db = _make_db(tmp_path)
+    channel = _make_channel(db, apns=FakeApns())
+    ws = FakeWs()
+    await channel._handle_register(
+        cast(Any, ws),
+        {
+            "type": IOS_MSG_TYPE_REGISTER,
+            "device_id": "ios-keychain-id",
+            "label": "iPhone",
+            "pairing_token": "pair-me",
+        },
+    )
+
+    message_id, outbox_id = await channel._log_and_send(
+        "ios-keychain-id", "linked message", None, None
+    )
+
+    assert message_id is not None and outbox_id is not None
+    device = db.devices.get_by_identifier("ios-keychain-id")
+    assert device is not None and device.id is not None
+    pending = db.ios.pending_for_device(device.id)
+    assert pending[0].id == outbox_id
+    assert pending[0].message_log_id == message_id
 
 
 @pytest.mark.asyncio

--- a/penny/penny/tests/channels/test_startup_announcement.py
+++ b/penny/penny/tests/channels/test_startup_announcement.py
@@ -53,6 +53,7 @@ class StartupReadyChannel(MessageChannel):
         attachments: list[str] | None = None,
         quote_message=None,
         source_name: str | None = None,
+        message_log_id: int | None = None,
     ) -> int | None:
         self.sent.append((recipient, message))
         return len(self.sent)

--- a/penny/penny/tests/database/test_migrations.py
+++ b/penny/penny/tests/database/test_migrations.py
@@ -80,7 +80,7 @@ class TestMigrate:
         conn.close()
 
         count = migrate(db_path)
-        assert count == 79
+        assert count == 80
 
         conn = sqlite3.connect(db_path)
         tables = {
@@ -120,7 +120,7 @@ class TestMigrate:
 
         count1 = migrate(db_path)
         count2 = migrate(db_path)
-        assert count1 == 79
+        assert count1 == 80
         assert count2 == 0
 
     def test_tracks_in_migrations_table(self, tmp_path):
@@ -158,8 +158,8 @@ class TestMigrate:
         conn.close()
 
         count = migrate(db_path)
-        # 0001 is skipped; 0002 through 0079 run = 78 migrations
-        assert count == 78
+        # 0001 is skipped; 0002 through 0080 run = 79 migrations
+        assert count == 79
 
     def test_bootstrap_with_tables_already_present(self, tmp_path):
         """If tables already exist (from SQLModel.create_tables), migration should succeed."""
@@ -185,7 +185,7 @@ class TestMigrate:
         conn.close()
 
         count = migrate(db_path)
-        assert count == 79  # all migrations applied
+        assert count == 80  # all migrations applied
 
         conn = sqlite3.connect(db_path)
         cursor = conn.execute("SELECT name FROM _migrations")

--- a/scripts/client-check.sh
+++ b/scripts/client-check.sh
@@ -8,16 +8,16 @@
 set -euo pipefail
 
 BUILD_INFO_DERIVED_DATA=""
-UDID=$(xcodebuild -project penny-client/PennyClient.xcodeproj -scheme PennyClient -showdestinations 2>/dev/null \
+UDID=$(xcodebuild -project penny-client/PennyClient.xcodeproj -scheme PennyClient -showdestinations 2>&1 \
     | awk -F'[{},]' '
-        /platform:iOS Simulator/ && /name:iPhone/ {
+        /platform:iOS Simulator/ && /name:iPhone/ && !found {
             for (i = 1; i <= NF; i++) {
                 gsub(/^ +| +$/, "", $i)
                 if ($i ~ /^id:/) {
                     sub(/^id:/, "", $i)
                     if ($i !~ /^dvtdevice-/) {
                         print $i
-                        exit
+                        found = 1
                     }
                 }
             }


### PR DESCRIPTION

<img width="346" height="498" alt="8FE1AFB6-96CB-48E0-BF9F-A58A710F9689_4_5005_c" src="https://github.com/user-attachments/assets/7906bd75-65a8-47a5-9379-b299084b08f5" />

The iOS history sync is a local-first, paginated flow:

1. On app startup, `MessageView.ViewModel.connect()` first loads the newest messages from the local SQLite database, then opens the WebSocket.

2. The client can explicitly start a history sync through `startHistorySync(channelTypes:)`. It sends:

   ```json
   {
     "type": "history_request",
     "limit": 30,
     "before": "...cursor...",
     "channel_types": ["ios"]
   }
   ```

3. The backend queries the shared `MessageLog` table, scoped to the registered device and selected channel types. It includes incoming and outgoing messages, excludes reactions, orders by `(timestamp, message_id)`, and returns one page plus a cursor.

4. The cursor contains both timestamp and message ID, so messages with identical timestamps are paginated deterministically.

5. Each history response is decoded into `ChatMessage` values. The client:

   - Deduplicates repeated canonical server IDs.
   - Reconciles optimistic local outgoing messages with their canonical history records.
   - Persists messages into SQLite, including attachment data.
   - Replaces or appends messages in the live displayed list as appropriate.

6. The newest history page is merged into the visible list immediately. Older history pages are primarily used to populate SQLite; the user-facing list reads older pages locally as the user scrolls upward.

7. Local paging uses SQLite cursors and filters. The view model loads the latest page initially, then requests older pages with a `(createdAt, id)` cursor and prepends them while preserving scroll position.

8. Live WebSocket outbox messages use the same persistence and deduplication path, allowing newly received messages and locally loaded history to converge into one chronological list.

Main implementation areas:

- Client protocol and persistence: [PennyService.swift](/Users/robertwaltham/Library/CloudStorage/Dropbox/penny/penny-client/PennyClient/Service/PennyService.swift)
- Message reconciliation helpers: [PennyService+MessageSync.swift](/Users/robertwaltham/Library/CloudStorage/Dropbox/penny/penny-client/PennyClient/Service/PennyService+MessageSync.swift)
- SQLite storage and paging: [DatabaseService.swift](/Users/robertwaltham/Library/CloudStorage/Dropbox/penny/penny-client/PennyClient/Service/DatabaseService.swift)
- Display paging/scroll state: [MessageView+ViewModel.swift](/Users/robertwaltham/Library/CloudStorage/Dropbox/penny/penny-client/PennyClient/Views/MessageView+ViewModel.swift)
- Backend history endpoint: [channel.py](/Users/robertwaltham/Library/CloudStorage/Dropbox/penny/penny/penny/channels/ios/channel.py) and [message_store.py](/Users/robertwaltham/Library/CloudStorage/Dropbox/penny/penny/penny/database/message_store.py)