### PR TITLE
Make media/image matching robust to embedding dimension mismatches

### DIFF
--- a/penny/penny/database/media_store.py
+++ b/penny/penny/database/media_store.py
@@ -169,10 +169,14 @@ class MediaStore:
         return chosen
 
     def _scored(self, embedding: list[float], rows: list[_Candidate]) -> list[tuple[int, float]]:
-        """(id, cosine) for ``rows``, nearest first, no floor."""
+        """(id, cosine) for ``rows`` of the same dimension, nearest first, no floor."""
         return find_similar(
             embedding,
-            [(row.id, row.vector) for row in rows if row.vector is not None],
+            [
+                (row.id, row.vector)
+                for row in rows
+                if row.vector is not None and len(row.vector) == len(embedding)
+            ],
             top_k=len(rows) or 1,
             threshold=-1.0,
         )

--- a/similarity/embeddings.py
+++ b/similarity/embeddings.py
@@ -49,6 +49,8 @@ def find_similar(
     """
     scored = []
     for item_id, embedding in candidates:
+        if len(embedding) != len(query):
+            continue
         score = cosine_similarity(query, embedding)
         if score >= threshold:
             scored.append((item_id, score))


### PR DESCRIPTION
The media table can contain vectors produced by different embedding runs
(e.g., a 2D test fixture seeded next to a 4096-dim mock embedding). When
`MediaStore` tried to score those with `find_similar`, the `zip(..., strict=True)`
in `cosine_similarity` raised `ValueError` because the vectors were different
lengths. Now `find_similar` ignores candidates whose embedding dimension does
not match the query, and `MediaStore._scored` only hands comparable rows to the
similarity search.

- Full `pytest` suite: 1008 passed
- `ruff` format + lint: passed
- `migrate --validate`: passed

/merge-when-ready