### PR TITLE
Refactor layout where search and card layout are on a separate screen

### DIFF
--- a/penny-client/PennyClient/Service/Prefs.swift
+++ b/penny-client/PennyClient/Service/Prefs.swift
@@ -108,11 +108,6 @@ extension Prefs {
         set { setSecureString(newValue, forKey: .password) }
     }
 
-    var isMessageLayoutSwitcherEnabled: Bool {
-        get { bool(forKey: .isMessageLayoutSwitcherEnabled) }
-        set { set(newValue, forKey: .isMessageLayoutSwitcherEnabled) }
-    }
-
     struct Key: RawRepresentable, Hashable, ExpressibleByStringLiteral {
         let rawValue: String
 
@@ -134,7 +129,6 @@ extension Prefs.Key {
     static let webSocketURL = Self("connection.webSocketURL")
     static let username = Self("connection.username")
     static let password = Self("connection.password")
-    static let isMessageLayoutSwitcherEnabled = Self("features.messageLayoutSwitcherEnabled")
     static let historySyncState = Self("history.syncState")
 }
 

--- a/penny-client/PennyClient/Views/AdminFeatureViewModels.swift
+++ b/penny-client/PennyClient/Views/AdminFeatureViewModels.swift
@@ -206,7 +206,6 @@ final class SettingsViewModel {
     var webSocketURL: String
     var username: String
     var password: String
-    var isMessageLayoutSwitcherEnabled: Bool
     var editedConfigValues: [String: String] = [:]
     var domainDraft = ""
     var domainPermission: DomainPermission = .allowed
@@ -217,7 +216,6 @@ final class SettingsViewModel {
         webSocketURL = prefs.webSocketURL ?? ""
         username = prefs.username ?? ""
         password = prefs.password ?? ""
-        isMessageLayoutSwitcherEnabled = prefs.isMessageLayoutSwitcherEnabled
     }
 
     var canSaveConnection: Bool {
@@ -268,7 +266,6 @@ final class SettingsViewModel {
         prefs.webSocketURL = webSocketURL.trimmingCharacters(in: .whitespacesAndNewlines)
         prefs.username = username.trimmingCharacters(in: .whitespacesAndNewlines)
         prefs.password = password
-        prefs.isMessageLayoutSwitcherEnabled = isMessageLayoutSwitcherEnabled
         client.reconnect()
     }
 

--- a/penny-client/PennyClient/Views/MessageSearchView.swift
+++ b/penny-client/PennyClient/Views/MessageSearchView.swift
@@ -1,3 +1,4 @@
+import Observation
 import SwiftUI
 import UIKit
 
@@ -5,152 +6,368 @@ struct MessageSearchView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var query = ""
     @State private var selectedMessage: ChatMessage?
-    @State private var selectedFilter: MessageView.MessageFilter = .all
-    @State private var searchService: SearchService
-    @State private var searchTask: Task<Void, Never>?
+    @State private var viewModel: MessageSearchViewModel
 
     private let onReply: (ChatMessage) -> Void
 
     init(client: PennyService, onReply: @escaping (ChatMessage) -> Void) {
         self.onReply = onReply
-        _searchService = State(initialValue: SearchService(client: client))
+        _viewModel = State(initialValue: MessageSearchViewModel(client: client))
     }
 
-    private var searchResultColumns: [GridItem] {
-        Array(
-            repeating: GridItem(.flexible(), spacing: MessageView.MessageLayout.compact.itemSpacing, alignment: .top),
-            count: MessageView.MessageLayout.compact.columnCount
+    var body: some View {
+        NavigationStack {
+            content
+                .navigationTitle("Search Messages")
+                .navigationBarTitleDisplayMode(.inline)
+                .searchable(
+                    text: $query,
+                    placement: .navigationBarDrawer(displayMode: .always),
+                    prompt: "Search by meaning"
+                )
+                .onChange(of: query) { _, _ in
+                    resetSearchAndLoadHistory()
+                }
+                .onChange(of: viewModel.selectedFilter) { _, _ in
+                    filterChanged()
+                }
+                .onChange(of: viewModel.selectedLayout) { _, _ in
+                    viewModel.resetHistoryPaging()
+                }
+                .onSubmit(of: .search) {
+                    startSearch()
+                }
+                .onDisappear {
+                    viewModel.cancelTasks()
+                }
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        filterMenu
+                    }
+                    ToolbarItem(placement: .principal) {
+                        layoutPicker
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+                .sheet(item: $selectedMessage) { message in
+                    MessageCardDetailSheet(message: message)
+                }
+        }
+        .task {
+            await viewModel.loadInitialHistory()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.searchService.isSearching {
+            ProgressView("Searching...")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if !trimmedQuery.isEmpty && viewModel.searchService.hasSearched {
+            semanticResults
+        } else {
+            history
+        }
+    }
+
+    private var history: some View {
+        MessageCardGrid(
+            messages: viewModel.displayedMessages,
+            layout: viewModel.selectedLayout,
+            onMessageTap: { selectedMessage = $0 },
+            onReply: reply,
+            onLastMessageAppear: loadMoreHistory
         )
+        .overlay {
+            if let errorMessage = viewModel.historyErrorMessage {
+                ContentUnavailableView(
+                    "History Unavailable",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(errorMessage)
+                )
+            } else if viewModel.displayedMessages.isEmpty && !viewModel.isLoadingHistory {
+                ContentUnavailableView(
+                    "No Messages",
+                    systemImage: viewModel.selectedFilter.systemImage,
+                    description: Text("No messages match the selected filter.")
+                )
+            } else if viewModel.isLoadingHistory {
+                ProgressView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var semanticResults: some View {
+        if let errorMessage = viewModel.searchService.errorMessage {
+            ContentUnavailableView(
+                "Search Unavailable",
+                systemImage: "exclamationmark.triangle",
+                description: Text(errorMessage)
+            )
+        } else if viewModel.searchService.results.isEmpty {
+            ContentUnavailableView(
+                "No Matches",
+                systemImage: "magnifyingglass",
+                description: Text("Try a different phrase.")
+            )
+        } else {
+            MessageCardGrid(
+                messages: viewModel.searchService.results.map(\.message),
+                layout: viewModel.selectedLayout,
+                onMessageTap: { selectedMessage = $0 },
+                onReply: reply,
+                badge: { message in
+                    guard let result = viewModel.searchService.results.first(where: { $0.message.id == message.id }) else {
+                        return nil
+                    }
+                    return "\(Int(result.similarity * 100))%"
+                }
+            )
+        }
     }
 
     private var filterMenu: some View {
         Menu {
-            Picker("Filter Messages", selection: $selectedFilter) {
+            Picker("Filter Messages", selection: $viewModel.selectedFilter) {
                 ForEach(MessageView.MessageFilter.allCases) { filter in
                     Label(filter.title, systemImage: filter.systemImage)
                         .tag(filter)
                 }
             }
         } label: {
-            Image(systemName: selectedFilter == .all ? "line.3.horizontal.decrease.circle" : "line.3.horizontal.decrease.circle.fill")
+            Image(systemName: viewModel.selectedFilter == .all
+                ? "line.3.horizontal.decrease.circle"
+                : "line.3.horizontal.decrease.circle.fill")
                 .frame(width: 28, height: 28)
                 .contentShape(Circle())
         }
         .buttonStyle(.borderless)
         .foregroundStyle(.primary)
         .accessibilityLabel("Filter messages")
-        .accessibilityValue(selectedFilter.title)
+        .accessibilityValue(viewModel.selectedFilter.title)
     }
 
-    var body: some View {
-        NavigationStack {
-            Group {
-                if searchService.isSearching {
-                    ProgressView("Searching...")
-                } else if let errorMessage = searchService.errorMessage {
-                    ContentUnavailableView("Search Unavailable", systemImage: "exclamationmark.triangle", description: Text(errorMessage))
-                } else if searchService.results.isEmpty {
-                    ContentUnavailableView(
-                        searchService.hasSearched ? "No Matches" : "Search Messages",
-                        systemImage: "magnifyingglass",
-                        description: Text(searchService.hasSearched ? "Try a different phrase." : "Search your conversation history by meaning.")
-                    )
-                } else {
-                    ScrollView {
-                        LazyVGrid(columns: searchResultColumns, spacing: MessageView.MessageLayout.compact.itemSpacing) {
-                            ForEach(searchService.results) { result in
-                                searchResultCard(result)
-                            }
-                        }
-                        .padding(.horizontal, MessageView.MessageLayout.compact.horizontalPadding)
-                        .padding(.vertical, 12)
-                    }
-                    .background(Color(.systemGroupedBackground))
-                }
-            }
-            .navigationTitle("Search Messages")
-            .navigationBarTitleDisplayMode(.inline)
-            .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search by meaning")
-            .onChange(of: query) { _, _ in
-                cancelSearch()
-                searchService.clear()
-            }
-            .onChange(of: selectedFilter) { _, _ in
-                handleFilterChanged()
-            }
-            .onSubmit(of: .search) {
-                startSearch()
-            }
-            .onDisappear {
-                cancelSearch()
-            }
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    filterMenu
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Cancel") { dismiss() }
-                }
-            }
-            .sheet(item: $selectedMessage) { message in
-                MessageCardDetailSheet(message: message)
-            }
+    private var layoutPicker: some View {
+        Picker("Card layout", selection: $viewModel.selectedLayout) {
+            Text("2").tag(MessageView.MessageLayout.compact)
+            Text("3").tag(MessageView.MessageLayout.media)
+        }
+        .pickerStyle(.segmented)
+        .frame(width: 96)
+        .accessibilityLabel("Card layout")
+    }
+
+    private var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func startSearch() {
+        guard !trimmedQuery.isEmpty else {
+            resetSearchAndLoadHistory()
+            return
+        }
+        viewModel.cancelHistoryTask()
+        Task {
+            await viewModel.searchService.search(trimmedQuery, filter: viewModel.selectedFilter.pageFilter)
         }
     }
 
-    private func searchResultCard(_ result: MessageSearchResult) -> some View {
-        Button {
-            selectedMessage = result.message
-        } label: {
-            ChatMessageView(message: result.message, layout: .compact)
-                .overlay(alignment: .bottomTrailing) {
-                    Text("\(Int(result.similarity * 100))%")
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 3)
-                        .background(.regularMaterial, in: Capsule())
-                        .padding(8)
-                }
+    private func resetSearchAndLoadHistory() {
+        viewModel.searchService.clear()
+        guard trimmedQuery.isEmpty else { return }
+        Task {
+            await viewModel.loadInitialHistory()
         }
-        .buttonStyle(.plain)
-        .contextMenu {
-            Button {
-                reply(to: result.message)
-            } label: {
-                Label("Reply", systemImage: "arrowshape.turn.up.left")
-            }
+    }
 
-            Button {
-                UIPasteboard.general.string = result.message.content
-            } label: {
-                Label("Copy", systemImage: "doc.on.doc")
-            }
+    private func filterChanged() {
+        if trimmedQuery.isEmpty {
+            Task { await viewModel.loadInitialHistory() }
+        } else if viewModel.searchService.hasSearched {
+            startSearch()
         }
+    }
+
+    private func loadMoreHistory() {
+        guard trimmedQuery.isEmpty else { return }
+        Task { await viewModel.loadMoreHistory() }
     }
 
     private func reply(to message: ChatMessage) {
         onReply(message)
         dismiss()
     }
+}
 
-    private func startSearch() {
-        cancelSearch()
-        searchTask = Task { await searchService.search(query, filter: selectedFilter.pageFilter) }
+@MainActor
+@Observable
+final class MessageSearchViewModel {
+    let client: PennyService
+    let searchService: SearchService
+    var selectedFilter: MessageView.MessageFilter = .all
+    var selectedLayout: MessageView.MessageLayout = .compact
+    var displayedMessages: [ChatMessage] = []
+    var isLoadingHistory = false
+    var historyErrorMessage: String?
+
+    @ObservationIgnored private let pageSize: Int
+    @ObservationIgnored private var nextCursor: MessagePageCursor?
+    @ObservationIgnored private var hasMoreHistory = false
+    @ObservationIgnored private var historyTask: Task<Void, Never>?
+
+    init(client: PennyService, pageSize: Int = 30, searchService: SearchService? = nil) {
+        self.client = client
+        self.pageSize = max(1, pageSize)
+        self.searchService = searchService ?? SearchService(client: client)
     }
 
-    private func handleFilterChanged() {
-        cancelSearch()
-        guard searchService.hasSearched,
-              !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            searchService.clear()
-            return
+    var canLoadMoreHistory: Bool {
+        hasMoreHistory && !isLoadingHistory
+    }
+
+    func loadInitialHistory() async {
+        historyTask?.cancel()
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.loadInitialHistoryPage()
         }
-        startSearch()
+        historyTask = task
+        await task.value
     }
 
-    private func cancelSearch() {
-        searchTask?.cancel()
-        searchTask = nil
+    func loadMoreHistory() async {
+        guard canLoadMoreHistory, let nextCursor else { return }
+        isLoadingHistory = true
+        defer { isLoadingHistory = false }
+
+        let page = await client.requestMessagePage(
+            MessagePageRequest(limit: pageSize, before: nextCursor, filter: selectedFilter.pageFilter)
+        )
+        let existingIDs = Set(displayedMessages.map(\.id))
+        displayedMessages.insert(contentsOf: page.messages.filter { !existingIDs.contains($0.id) }, at: 0)
+        self.nextCursor = page.nextCursor
+        hasMoreHistory = page.hasMore
+    }
+
+    func resetHistoryPaging() {
+        nextCursor = nil
+        hasMoreHistory = false
+    }
+
+    func cancelHistoryTask() {
+        historyTask?.cancel()
+        historyTask = nil
+    }
+
+    func cancelTasks() {
+        cancelHistoryTask()
+        searchService.clear()
+    }
+
+    private func loadInitialHistoryPage() async {
+        isLoadingHistory = true
+        historyErrorMessage = nil
+        resetHistoryPaging()
+        defer { isLoadingHistory = false }
+
+        let page = await client.requestMessagePage(
+            MessagePageRequest(limit: pageSize, filter: selectedFilter.pageFilter)
+        )
+        guard !Task.isCancelled else { return }
+        displayedMessages = page.messages
+        nextCursor = page.nextCursor
+        hasMoreHistory = page.hasMore
+    }
+}
+
+private struct MessageCardGrid: View {
+    let messages: [ChatMessage]
+    let layout: MessageView.MessageLayout
+    let onMessageTap: (ChatMessage) -> Void
+    let onReply: (ChatMessage) -> Void
+    let badge: ((ChatMessage) -> String?)?
+    let onLastMessageAppear: (() -> Void)?
+
+    init(
+        messages: [ChatMessage],
+        layout: MessageView.MessageLayout,
+        onMessageTap: @escaping (ChatMessage) -> Void,
+        onReply: @escaping (ChatMessage) -> Void,
+        badge: ((ChatMessage) -> String?)? = nil,
+        onLastMessageAppear: (() -> Void)? = nil
+    ) {
+        self.messages = messages
+        self.layout = layout
+        self.onMessageTap = onMessageTap
+        self.onReply = onReply
+        self.badge = badge
+        self.onLastMessageAppear = onLastMessageAppear
+    }
+
+    private var columns: [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: layout.itemSpacing, alignment: .top), count: layout.columnCount)
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: layout.itemSpacing) {
+                ForEach(messages) { message in
+                    MessageCardCell(
+                        message: message,
+                        layout: layout,
+                        badge: badge?(message),
+                        onTap: { onMessageTap(message) },
+                        onReply: { onReply(message) }
+                    )
+                    .onAppear {
+                        guard message.id == messages.last?.id else { return }
+                        onLastMessageAppear?()
+                    }
+                }
+            }
+            .padding(.horizontal, layout.horizontalPadding)
+            .padding(.vertical, 12)
+        }
+        .background(Color(.systemGroupedBackground))
+    }
+}
+
+private struct MessageCardCell: View {
+    let message: ChatMessage
+    let layout: MessageView.MessageLayout
+    let badge: String?
+    let onTap: () -> Void
+    let onReply: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            ChatMessageView(message: message, layout: layout)
+                .overlay(alignment: .bottomTrailing) {
+                    if let badge {
+                        Text(badge)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(.regularMaterial, in: Capsule())
+                            .padding(8)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button(action: onReply) {
+                Label("Reply", systemImage: "arrowshape.turn.up.left")
+            }
+
+            Button {
+                UIPasteboard.general.string = message.content
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+        }
     }
 }

--- a/penny-client/PennyClient/Views/MessageView+ViewModel.swift
+++ b/penny-client/PennyClient/Views/MessageView+ViewModel.swift
@@ -85,9 +85,7 @@ extension MessageView {
     final class ViewModel {
         var client = PennyWebSocketClient()
         var draftMessage = ""
-        var isShowingConnectionError = false
         var isShowingSettings = false
-        var isShowingSearch = false
         var hasHiddenNewMessages = false
         var replyMessage: ChatMessage?
         var selectedMessageLayout: MessageLayout = .message

--- a/penny-client/PennyClient/Views/MessageView.swift
+++ b/penny-client/PennyClient/Views/MessageView.swift
@@ -11,7 +11,6 @@ struct MessageView: View {
     @State private var messageScrollFrames: [Int: CGRect] = [:]
     @State private var messageActionProxyHeights: [Int: CGFloat] = [:]
     @State private var messageContextScale: CGFloat = 1
-    @State private var shouldUseFastComposerScroll = false
     @State private var keyboardSettledScrollTask: Task<Void, Never>?
     @State private var typingIndicatorStatus = "Penny is typing"
     @State private var isTypingIndicatorVisible = false
@@ -56,10 +55,6 @@ struct MessageView: View {
                                 withTransaction(Transaction(animation: .easeOut(duration: 0.12))) {
                                     viewModel.startReply(to: message)
                                 }
-                                Task { @MainActor in
-                                    await Task.yield()
-                                    isComposerFocused = true
-                                }
                             }
                         } label: {
                             Image(systemName: "magnifyingglass")
@@ -68,6 +63,9 @@ struct MessageView: View {
                         }
                         .buttonStyle(.borderless)
                         .foregroundStyle(.primary)
+                        .simultaneousGesture(TapGesture().onEnded {
+                            isComposerFocused = false
+                        })
                         .accessibilityLabel("Search messages")
 
                         Button {
@@ -804,7 +802,6 @@ private extension MessageView {
     func messageActionMenu(for message: ChatMessage) -> some View {
         VStack(spacing: 0) {
             Button {
-                shouldUseFastComposerScroll = true
                 withTransaction(Transaction(animation: .easeOut(duration: 0.12))) {
                     viewModel.startReply(to: message)
                     dismissMessageActions()

--- a/penny-client/PennyClient/Views/MessageView.swift
+++ b/penny-client/PennyClient/Views/MessageView.swift
@@ -4,7 +4,6 @@ import UIKit
 struct MessageView: View {
     @Environment(\.scenePhase) private var scenePhase
     @State private var viewModel = ViewModel()
-    @State private var isMessageLayoutSwitcherEnabled = Prefs.shared.isMessageLayoutSwitcherEnabled
     @State private var isShowingActivity = false
     @State private var presentedCardMessage: ChatMessage?
     @State private var activeMessageContext: MessageActionContext?
@@ -22,38 +21,15 @@ struct MessageView: View {
     @State private var pendingIncomingAutoScrollMessageID: Int?
     @State private var lastTopScrolledMessageID: Int?
     @State private var chatViewportFrame: CGRect = .zero
-    @State private var messageLayoutSwitcherHeight: CGFloat = 0
     @State private var selectedPennyNavigation: PennyNavigationDestination?
     @FocusState private var isComposerFocused: Bool
-
-    private var effectiveMessageLayout: MessageLayout {
-        isMessageLayoutSwitcherEnabled ? viewModel.selectedMessageLayout : .message
-    }
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                if effectiveMessageLayout == .message {
-                    chatScrollView
-                } else {
-                    cardScrollView(layout: effectiveMessageLayout)
-                }
+                chatScrollView
             }
             .background(Color(.systemGroupedBackground).ignoresSafeArea())
-            .overlay(alignment: .top) {
-                if isMessageLayoutSwitcherEnabled {
-                    messageLayoutSelector
-                        .padding(.top, 10)
-                        .background {
-                            GeometryReader { geometry in
-                                Color.clear.preference(
-                                    key: MessageLayoutSwitcherHeightPreferenceKey.self,
-                                    value: geometry.size.height
-                                )
-                            }
-                        }
-                }
-            }
             .safeAreaInset(edge: .bottom) {
                 composer
             }
@@ -61,7 +37,6 @@ struct MessageView: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     HStack(spacing: 8) {
-                        messageFilterMenu
                         pennyNavigationMenu
 
                         if viewModel.hasHiddenNewMessages {
@@ -76,8 +51,16 @@ struct MessageView: View {
 
                 ToolbarItem(placement: .topBarTrailing) {
                     HStack(spacing: 14) {
-                        Button {
-                            viewModel.isShowingSearch = true
+                        NavigationLink {
+                            MessageSearchView(client: viewModel.client) { message in
+                                withTransaction(Transaction(animation: .easeOut(duration: 0.12))) {
+                                    viewModel.startReply(to: message)
+                                }
+                                Task { @MainActor in
+                                    await Task.yield()
+                                    isComposerFocused = true
+                                }
+                            }
                         } label: {
                             Image(systemName: "magnifyingglass")
                                 .frame(width: 28, height: 28)
@@ -86,20 +69,6 @@ struct MessageView: View {
                         .buttonStyle(.borderless)
                         .foregroundStyle(.primary)
                         .accessibilityLabel("Search messages")
-
-                        if viewModel.client.lastError != nil {
-                            Button {
-                                viewModel.isShowingConnectionError = true
-                            } label: {
-                                Image(systemName: "info.circle")
-                                    .frame(width: 28, height: 28)
-                                    .contentShape(Circle())
-                                    .foregroundStyle(.red)
-                            }
-                            .buttonStyle(.borderless)
-                            .foregroundStyle(.primary)
-                            .accessibilityLabel("Connection error")
-                        }
 
                         Button {
                             viewModel.isShowingSettings = true
@@ -115,27 +84,8 @@ struct MessageView: View {
                     }
                 }
             }
-            .alert("Connection Error", isPresented: $viewModel.isShowingConnectionError, presenting: viewModel.client.lastError) { _ in
-                Button("Reconnect") {
-                    viewModel.reconnect()
-                }
-                Button("OK", role: .cancel) {}
-            } message: { errorMessage in
-                Text(errorMessage)
-            }
             .sheet(isPresented: $viewModel.isShowingSettings) {
                 SettingsView(client: viewModel.client)
-            }
-            .sheet(isPresented: $viewModel.isShowingSearch) {
-                MessageSearchView(client: viewModel.client) { message in
-                    withTransaction(Transaction(animation: .easeOut(duration: 0.12))) {
-                        viewModel.startReply(to: message)
-                    }
-                    Task { @MainActor in
-                        await Task.yield()
-                        isComposerFocused = true
-                    }
-                }
             }
             .sheet(isPresented: $isShowingActivity) {
                 AgentActivityView(client: viewModel.client)
@@ -154,15 +104,8 @@ struct MessageView: View {
             .onPreferenceChange(ChatViewportFramePreferenceKey.self) { frame in
                 chatViewportFrame = frame
             }
-            .onPreferenceChange(MessageLayoutSwitcherHeightPreferenceKey.self) { height in
-                messageLayoutSwitcherHeight = height
-            }
             .overlay {
                 messageActionOverlay
-            }
-            .onChange(of: viewModel.isShowingSettings) { _, isShowingSettings in
-                guard !isShowingSettings else { return }
-                refreshFeaturePreferences()
             }
         }
         .task {
@@ -177,7 +120,6 @@ struct MessageView: View {
         .onDisappear {
             keyboardSettledScrollTask?.cancel()
             typingIndicatorFadeTask?.cancel()
-            viewModel.disconnect()
         }
     }
 
@@ -190,7 +132,7 @@ struct MessageView: View {
                     topMessageLoader(proxy: proxy)
 
                     if viewModel.displayedMessages.isEmpty {
-                        EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
+                        EmptyMessageFilterView(filter: .all)
                     } else {
                         messageGrid(layout: .message) { message in
                             scrollToMessageTopIfNeeded(message.id, with: proxy)
@@ -297,44 +239,6 @@ struct MessageView: View {
         viewModel.client.foregroundProgress?.currentStatus ?? "Penny is typing"
     }
 
-    private func cardScrollView(layout: MessageLayout) -> some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(spacing: 12) {
-                    olderMessagesLoader(proxy: proxy)
-
-                    topMessageLoader(proxy: proxy)
-
-                    if viewModel.displayedMessages.isEmpty {
-                        EmptyMessageFilterView(filter: viewModel.selectedMessageFilter)
-                    } else {
-                        messageGrid(layout: layout)
-                    }
-
-                    bottomSpacer
-                }
-                .padding(.horizontal, layout.horizontalPadding)
-                .padding(.top, messageListTopPadding)
-            }
-            .background(Color(.systemGroupedBackground))
-            .coordinateSpace(name: messageScrollCoordinateSpace)
-            .scrollDismissesKeyboard(.interactively)
-            .onAppear {
-                scheduleScrollToBottom(with: proxy, animated: false)
-            }
-            .onChange(of: viewModel.displayedMessages.map(\.id)) { previousIDs, currentIDs in
-                prepareArrivalAnimations(previousIDs: previousIDs, currentIDs: currentIDs)
-            }
-            .onChange(of: viewModel.scrollToBottomRequest) { _, _ in
-                scheduleScrollToBottom(
-                    with: proxy,
-                    animated: false,
-                    shouldSettleLayout: viewModel.shouldSettleScrollToBottom
-                )
-            }
-        }
-    }
-
     private var pennyNavigationMenu: some View {
         Menu {
             ForEach(PennyNavigationDestination.allCases) { destination in
@@ -364,30 +268,10 @@ struct MessageView: View {
         }
     }
 
-    private var messageFilterMenu: some View {
-        Menu {
-            Picker("Filter Messages", selection: $viewModel.selectedMessageFilter) {
-                ForEach(MessageFilter.allCases) { filter in
-                    Label(filter.title, systemImage: filter.systemImage)
-                        .tag(filter)
-                }
-            }
-        } label: {
-            Image(systemName: viewModel.selectedMessageFilter == .all ? "line.3.horizontal.decrease.circle" : "line.3.horizontal.decrease.circle.fill")
-                .frame(width: 28, height: 28)
-                .contentShape(Circle())
-        }
-        .buttonStyle(.borderless)
-        .foregroundStyle(.primary)
-        .accessibilityLabel("Filter messages")
-        .accessibilityValue(viewModel.selectedMessageFilter.title)
-    }
-
     private var hiddenNewMessagesButton: some View {
         Button {
             Task {
                 await viewModel.clearFiltersAndShowNewMessages()
-                viewModel.selectedMessageLayout = .message
             }
         } label: {
             Image(systemName: "message.badge")
@@ -397,28 +281,6 @@ struct MessageView: View {
         .buttonStyle(.borderless)
         .foregroundStyle(Color.accentColor)
         .accessibilityLabel("Show new messages")
-    }
-
-    private var messageLayoutSelector: some View {
-        HStack(spacing: 4) {
-            ForEach(MessageLayout.allCases) { layout in
-                Button {
-                    changeMessageLayout(to: layout)
-                } label: {
-                    Image(systemName: viewModel.selectedMessageLayout == layout ? "\(layout.rawValue).circle.fill" : layout.systemImage)
-                        .font(.system(size: 17, weight: .semibold))
-                        .frame(width: 36, height: 32)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(viewModel.selectedMessageLayout == layout ? Color.accentColor : .secondary)
-                .accessibilityLabel("\(layout.title) layout")
-            }
-        }
-        .padding(4)
-        .glassEffect(.regular, in: .capsule)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Message layout")
     }
 
     private var titleBar: some View {
@@ -678,25 +540,6 @@ private extension MessageView {
             }
     }
 
-    func refreshFeaturePreferences() {
-        isMessageLayoutSwitcherEnabled = Prefs.shared.isMessageLayoutSwitcherEnabled
-    }
-
-    func changeMessageLayout(to layout: MessageLayout) {
-        guard viewModel.selectedMessageLayout != layout else { return }
-        if layout != .message {
-            isComposerFocused = false
-            keyboardSettledScrollTask?.cancel()
-        }
-
-        var transaction = Transaction(animation: .spring(response: 0.34, dampingFraction: 0.86))
-        transaction.disablesAnimations = false
-        withTransaction(transaction) {
-            viewModel.selectedMessageLayout = layout
-        }
-        viewModel.requestScrollToBottom()
-    }
-
     func scheduleScrollToBottom(
         with proxy: ScrollViewProxy,
         animated: Bool = true,
@@ -792,13 +635,11 @@ private extension MessageView {
     }
 
     var chatViewportTopOcclusion: CGFloat {
-        isMessageLayoutSwitcherEnabled ? messageListTopPadding : 0
+        0
     }
 
     var messageListTopPadding: CGFloat {
-        guard isMessageLayoutSwitcherEnabled else { return 12 }
-        let measuredSwitcherHeight = messageLayoutSwitcherHeight > 0 ? messageLayoutSwitcherHeight : 50
-        return measuredSwitcherHeight + 8
+        12
     }
 
     func shouldScrollToMessage(_ id: Int) -> Bool {
@@ -807,7 +648,6 @@ private extension MessageView {
     }
 
     func incomingMessageAutoScrollDestination(for id: Int) -> IncomingMessageAutoScrollDestination? {
-        guard effectiveMessageLayout == .message else { return .bottomAnchor }
         guard let message = viewModel.displayedMessages.last(where: { $0.id == id }) else { return nil }
         guard !message.isOutgoing else { return .bottomAnchor }
         guard let frame = messageFrames[id], visibleChatViewportFrame.height > 0 else { return nil }
@@ -871,7 +711,7 @@ private extension MessageView {
             measuredHeight: measuredProxyHeight,
             maxHeight: maximumProxyHeight
         )
-        let fallbackProxyHeight = effectiveMessageLayout == .message ? context.frame.height : maximumProxyHeight
+        let fallbackProxyHeight = context.frame.height
         let proxyHeight = shouldScrollProxy ? maximumProxyHeight : min(maximumProxyHeight, max(1, measuredProxyHeight ?? fallbackProxyHeight))
         let stackHeight = proxyHeight + estimatedMenuHeight + stackSpacing
         let leading = actionProxyLeading(for: context, width: stackWidth, in: containerSize)
@@ -921,17 +761,11 @@ private extension MessageView {
 
     func actionProxyWidth(for context: MessageActionContext, in containerSize: CGSize) -> CGFloat {
         let maximumWidth = max(1, containerSize.width - MessageLayout.message.horizontalPadding * 2)
-        guard effectiveMessageLayout != .message else {
-            return min(max(1, context.frame.width), maximumWidth)
-        }
-        return maximumWidth
+        return min(max(1, context.frame.width), maximumWidth)
     }
 
     func actionProxyLeading(for context: MessageActionContext, width: CGFloat, in containerSize: CGSize) -> CGFloat {
         let maximumLeading = max(MessageLayout.message.horizontalPadding, containerSize.width - width - MessageLayout.message.horizontalPadding)
-        if effectiveMessageLayout != .message {
-            return context.message.isOutgoing ? maximumLeading : MessageLayout.message.horizontalPadding
-        }
         return min(max(MessageLayout.message.horizontalPadding, context.frame.minX), maximumLeading)
     }
 
@@ -943,7 +777,7 @@ private extension MessageView {
         if let measuredHeight {
             return measuredHeight > maxHeight
         }
-        return context.frame.height > maxHeight || (effectiveMessageLayout != .message && context.message.content.count > 280)
+        return context.frame.height > maxHeight
     }
 
     @ViewBuilder
@@ -1108,15 +942,6 @@ private struct ChatViewportFramePreferenceKey: PreferenceKey {
     static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
         let next = nextValue()
         value = next.height > 0 ? next : value
-    }
-}
-
-private struct MessageLayoutSwitcherHeightPreferenceKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        let next = nextValue()
-        value = next > 0 ? next : value
     }
 }
 
@@ -1308,6 +1133,20 @@ private struct AgentActivityView: View {
     var body: some View {
         NavigationStack {
             List {
+                Section("Connection") {
+                    LabeledContent("Status", value: client.statusText)
+
+                    if let error = client.lastError {
+                        Text(error)
+                            .font(.subheadline)
+                            .foregroundStyle(.red)
+
+                        Button("Reconnect", systemImage: "arrow.clockwise") {
+                            client.reconnect()
+                        }
+                    }
+                }
+
                 if let foreground = client.foregroundProgress {
                     Section("Current message") {
                         progressRun(foreground)

--- a/penny-client/PennyClient/Views/SettingsView.swift
+++ b/penny-client/PennyClient/Views/SettingsView.swift
@@ -42,10 +42,6 @@ struct SettingsView: View {
                         .autocorrectionDisabled()
                 }
 
-                Section("Features") {
-                    Toggle("1-2-3 layout", isOn: $viewModel.isMessageLayoutSwitcherEnabled)
-                }
-
                 Section("History") {
                     ForEach(HistoryChannel.allCases) { channel in
                         Toggle(channel.title, isOn: Binding(

--- a/penny-client/PennyClientTests/MessageViewModelTests.swift
+++ b/penny-client/PennyClientTests/MessageViewModelTests.swift
@@ -311,6 +311,35 @@ struct MessageViewModelTests {
         #expect(viewModel.shouldShowTypingIndicator == false)
     }
 
+    @Test func searchHistoryDefaultsToCompactAndLoadsSelectedFilter() async {
+        let database = configuredDatabase()
+        saveFilterFixture(in: database)
+        let client = PennyWebSocketClient(databaseService: database, prefs: configuredPrefs())
+        let viewModel = MessageSearchViewModel(client: client, pageSize: 2)
+
+        viewModel.selectedFilter = .penny
+        await viewModel.loadInitialHistory()
+
+        #expect(viewModel.selectedLayout == .compact)
+        #expect(viewModel.displayedMessages.map(\.id) == [2, 5])
+
+        viewModel.selectedLayout = .media
+        #expect(viewModel.selectedLayout == .media)
+    }
+
+    @Test func searchHistoryLoadsOlderPagesForTheSelectedFilter() async {
+        let database = configuredDatabase()
+        saveFilterFixture(in: database)
+        let client = PennyWebSocketClient(databaseService: database, prefs: configuredPrefs())
+        let viewModel = MessageSearchViewModel(client: client, pageSize: 2)
+
+        viewModel.selectedFilter = .penny
+        await viewModel.loadInitialHistory()
+        await viewModel.loadMoreHistory()
+
+        #expect(viewModel.displayedMessages.map(\.id) == [1, 2, 5])
+    }
+
 }
 
 @MainActor

--- a/penny-client/PennyClientTests/PennyAdminViewModelTests.swift
+++ b/penny-client/PennyClientTests/PennyAdminViewModelTests.swift
@@ -180,7 +180,6 @@ struct PennyAdminViewModelTests {
         viewModel.webSocketURL = " wss://new.example/penny/ "
         viewModel.username = " bob "
         viewModel.password = "new-secret"
-        viewModel.isMessageLayoutSwitcherEnabled = true
         viewModel.saveConnection()
 
         let payloads = await sentPayloads(transport, count: 5)
@@ -201,7 +200,6 @@ struct PennyAdminViewModelTests {
         #expect(prefs.webSocketURL == "wss://new.example/penny/")
         #expect(prefs.username == "bob")
         #expect(prefs.password == "new-secret")
-        #expect(prefs.isMessageLayoutSwitcherEnabled)
         client.disconnect()
     }
 }

--- a/penny-client/PennyClientTests/PrefsTests.swift
+++ b/penny-client/PennyClientTests/PrefsTests.swift
@@ -69,19 +69,6 @@ struct PrefsTests {
         #expect(prefs.password == nil)
     }
 
-    @Test func messageLayoutSwitcherFeatureDefaultsToDisabled() {
-        let prefs = Prefs(userDefaults: makeUserDefaults(), keychain: InMemoryKeychain(), bundle: Bundle(for: EmptyBundleMarker.self))
-
-        #expect(prefs.isMessageLayoutSwitcherEnabled == false)
-    }
-
-    @Test func storesMessageLayoutSwitcherFeatureFlag() {
-        let prefs = Prefs(userDefaults: makeUserDefaults(), keychain: InMemoryKeychain(), bundle: Bundle(for: EmptyBundleMarker.self))
-
-        prefs.isMessageLayoutSwitcherEnabled = true
-
-        #expect(prefs.isMessageLayoutSwitcherEnabled)
-    }
 }
 
 private struct SamplePreference: Codable, Equatable {


### PR DESCRIPTION
<img width="346" height="498" alt="69F8A951-708C-4643-B2F3-2FC4AFB45E65_4_5005_c" src="https://github.com/user-attachments/assets/3a9e46eb-6bbb-49db-b73a-b8e9f9204d11" />
<img width="281" height="610" alt="AE879600-C129-408C-BF64-DAC2A16FFDB5_4_5005_c" src="https://github.com/user-attachments/assets/1d72e0a9-3085-4adf-8830-4c3a6ee21578" />

This moves the card layout and the search to a separate screen. The filter option is now only on the search screen. The user can tap a card to reply, which will move back to the chat window with a pinned reply in the message area. 