### PR TITLE
run sqlite ANALYZE on startup for both client and server

### DIFF
--- a/penny-client/PennyClient/Service/DatabaseService.swift
+++ b/penny-client/PennyClient/Service/DatabaseService.swift
@@ -72,6 +72,9 @@ final class DatabaseService {
         do {
             try MessageModel.createTable(database: databaseConnection)
             try migrateDatabase()
+            try measureQuery("analyze") {
+                try databaseConnection.execute("ANALYZE")
+            }
         } catch {
             fatalError(error.localizedDescription)
         }

--- a/penny/penny/database/database.py
+++ b/penny/penny/database/database.py
@@ -1,6 +1,7 @@
 """Database facade — composes domain-specific stores."""
 
 import logging
+import time
 from pathlib import Path
 
 from sqlmodel import Session, SQLModel, create_engine
@@ -80,6 +81,18 @@ class Database:
         """Create all tables if they don't exist."""
         SQLModel.metadata.create_all(self.engine)
         logger.info("Database tables created")
+
+    def analyze(self) -> None:
+        """Refresh SQLite query-planner statistics for the current schema."""
+        started = time.perf_counter()
+        try:
+            with self.engine.begin() as connection:
+                connection.exec_driver_sql("ANALYZE")
+        except Exception:
+            logger.exception("Database query failed: ANALYZE")
+            return
+        elapsed_ms = int((time.perf_counter() - started) * 1_000)
+        logger.info("Database query completed: ANALYZE (elapsed_ms=%d)", elapsed_ms)
 
     def get_session(self) -> Session:
         """Get a database session (for direct use by config modules)."""

--- a/penny/penny/penny.py
+++ b/penny/penny/penny.py
@@ -86,6 +86,7 @@ class Penny:
         self.db = Database(config.db_path, runtime=config.runtime)
         self.db.create_tables()
         migrate(config.db_path)
+        self.db.analyze()
         config.runtime._db = self.db
 
     def _create_llm_client(

--- a/penny/penny/tests/database/test_database.py
+++ b/penny/penny/tests/database/test_database.py
@@ -1,0 +1,30 @@
+"""Tests for the database facade's startup maintenance operations."""
+
+from penny.database import Database
+
+
+def test_analyze_refreshes_sqlite_statistics_and_logs_completion(tmp_path, caplog):
+    caplog.set_level("INFO", logger="penny.database.database")
+    db = Database(str(tmp_path / "test.db"))
+    db.create_tables()
+    with db.engine.begin() as connection:
+        connection.exec_driver_sql(
+            "INSERT INTO messagelog "
+            "(timestamp, direction, sender, content, is_reaction, processed) "
+            "VALUES ('2026-01-01T00:00:00Z', 'incoming', 'user', 'one', 0, 0), "
+            "('2026-01-01T00:00:01Z', 'incoming', 'user', 'two', 0, 0)"
+        )
+
+    db.analyze()
+
+    with db.engine.connect() as connection:
+        stat = connection.exec_driver_sql(
+            "SELECT 1 FROM sqlite_stat1 "
+            "WHERE tbl = 'messagelog' AND idx = 'ix_messagelog_timestamp'"
+        ).first()
+
+    assert stat is not None
+    assert any(
+        record.message.startswith("Database query completed: ANALYZE")
+        for record in caplog.records
+    )

--- a/penny/penny/tests/database/test_database.py
+++ b/penny/penny/tests/database/test_database.py
@@ -25,6 +25,5 @@ def test_analyze_refreshes_sqlite_statistics_and_logs_completion(tmp_path, caplo
 
     assert stat is not None
     assert any(
-        record.message.startswith("Database query completed: ANALYZE")
-        for record in caplog.records
+        record.message.startswith("Database query completed: ANALYZE") for record in caplog.records
     )


### PR DESCRIPTION
TIL: https://jvns.ca/blog/2026/07/17/learning-about-running-sqlite/#analyze-is-apparently-important

 run on startup; it took about ~770ms on my 2.5gb database. future improvement is to run it on a schedule (like once a week?)
