### PR TITLE
Add Invoice Ninja expense category support

### DIFF
--- a/penny/penny/plugins/invoiceninja/__init__.py
+++ b/penny/penny/plugins/invoiceninja/__init__.py
@@ -14,8 +14,11 @@ from penny.config import Config
 from penny.plugins import CAPABILITY_INVOICING, Plugin
 from penny.plugins.invoiceninja.client import InvoiceNinjaClient
 from penny.plugins.invoiceninja.tools import (
+    CreateExpenseCategoryTool,
     CreateExpenseTool,
+    GetExpenseCategoryTool,
     GetExpenseTool,
+    ListExpenseCategoriesTool,
     ListExpensesTool,
     ListInvoicesTool,
     UpdateExpenseTool,
@@ -58,6 +61,9 @@ class InvoiceNinjaPlugin(Plugin):
             ListExpensesTool(self._client),
             GetExpenseTool(self._client),
             UpdateExpenseTool(self._client),
+            CreateExpenseCategoryTool(self._client),
+            ListExpenseCategoriesTool(self._client),
+            GetExpenseCategoryTool(self._client),
         ]
 
     async def close(self) -> None:

--- a/penny/penny/plugins/invoiceninja/client.py
+++ b/penny/penny/plugins/invoiceninja/client.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import httpx
 
-from penny.plugins.invoiceninja.models import Expense, Invoice
+from penny.plugins.invoiceninja.models import Expense, ExpenseCategory, Invoice
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,15 @@ def _expense_from_data(data: dict[str, Any]) -> Expense:
         private_notes=data.get("private_notes"),
         vendor_id=data.get("vendor_id"),
         category_id=data.get("category_id"),
+    )
+
+
+def _expense_category_from_data(data: dict[str, Any]) -> ExpenseCategory:
+    """Build an ExpenseCategory from an InvoiceNinja API data object."""
+    return ExpenseCategory(
+        id=str(data.get("id", "")),
+        name=data.get("name", ""),
+        color=data.get("color"),
     )
 
 
@@ -233,6 +242,57 @@ class InvoiceNinjaClient:
         expense_data = resp.json().get("data", {})
         logger.info("Updated InvoiceNinja expense %s", expense_id)
         return _expense_from_data(expense_data)
+
+    async def create_expense_category(self, name: str) -> ExpenseCategory:
+        """Create a new expense category.
+
+        Args:
+            name: Name of the expense category.
+
+        Returns:
+            The created ExpenseCategory object.
+        """
+        url = f"{self._base_url}/api/v1/expense_categories"
+        resp = await self._http.post(url, json={"name": name})
+        resp.raise_for_status()
+        category_data = resp.json().get("data", {})
+        logger.info("Created InvoiceNinja expense category %s", category_data.get("id"))
+        return _expense_category_from_data(category_data)
+
+    async def list_expense_categories(self, *, limit: int = 50) -> list[ExpenseCategory]:
+        """List expense categories.
+
+        Args:
+            limit: Maximum number of categories to return.
+
+        Returns:
+            List of ExpenseCategory objects.
+        """
+        url = f"{self._base_url}/api/v1/expense_categories"
+        params = {"per_page": str(limit)}
+        resp = await self._http.get(url, params=params)
+        resp.raise_for_status()
+        categories: list[ExpenseCategory] = []
+        for category_data in resp.json().get("data", []):
+            categories.append(_expense_category_from_data(category_data))
+        logger.info("Listed %d InvoiceNinja expense categories", len(categories))
+        return categories
+
+    async def get_expense_category(self, category_id: str) -> ExpenseCategory:
+        """Fetch a single expense category by ID.
+
+        Args:
+            category_id: InvoiceNinja expense category ID.
+
+        Returns:
+            The ExpenseCategory object.
+        """
+        url = f"{self._base_url}/api/v1/expense_categories/{category_id}"
+        resp = await self._http.get(url)
+        resp.raise_for_status()
+        category_data = resp.json().get("data", {})
+        logger.info("Retrieved InvoiceNinja expense category %s", category_id)
+        return _expense_category_from_data(category_data)
 
     async def close(self) -> None:
         """Close the HTTP client."""

--- a/penny/penny/plugins/invoiceninja/models.py
+++ b/penny/penny/plugins/invoiceninja/models.py
@@ -5,6 +5,24 @@ from __future__ import annotations
 from pydantic import BaseModel
 
 
+class InvoiceNinjaCredentials(BaseModel):
+    """InvoiceNinja API credentials."""
+
+    api_token: str
+    base_url: str
+
+
+class ExpenseCategory(BaseModel):
+    """An InvoiceNinja expense category."""
+
+    id: str
+    name: str
+    color: str | None = None
+
+    def __str__(self) -> str:
+        return f"[{self.id}] {self.name}"
+
+
 class Expense(BaseModel):
     """An InvoiceNinja expense."""
 

--- a/penny/penny/plugins/invoiceninja/tools.py
+++ b/penny/penny/plugins/invoiceninja/tools.py
@@ -304,3 +304,115 @@ class UpdateExpenseTool(Tool):
             private_notes=args.private_notes,
         )
         return ToolResult(message=f"Updated expense: {expense}")
+
+
+class CreateExpenseCategoryArgs(ToolArgs):
+    """Arguments for creating an expense category."""
+
+    name: str = Field(description="Name of the new expense category.")
+
+
+class CreateExpenseCategoryTool(Tool):
+    """Create an expense category in InvoiceNinja."""
+
+    name = "create_expense_category"
+    description = "Create a new expense category in InvoiceNinja."
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Name of the new expense category."},
+        },
+        "required": ["name"],
+    }
+    args_model = CreateExpenseCategoryArgs
+
+    @classmethod
+    def to_action_str(cls, arguments: dict) -> str:
+        return "Creating InvoiceNinja expense category"
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        """Create an expense category."""
+        args = CreateExpenseCategoryArgs(**kwargs)
+        category = await self._client.create_expense_category(args.name)
+        return ToolResult(message=f"Created expense category: {category}")
+
+
+class ListExpenseCategoriesArgs(ToolArgs):
+    """Arguments for listing expense categories."""
+
+    limit: int = Field(default=50, description="Maximum number of categories to return.")
+
+
+class ListExpenseCategoriesTool(Tool):
+    """List expense categories from InvoiceNinja."""
+
+    name = "list_expense_categories"
+    description = "List expense categories from InvoiceNinja."
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of categories to return.",
+                "default": 50,
+            },
+        },
+        "required": [],
+    }
+    args_model = ListExpenseCategoriesArgs
+
+    @classmethod
+    def to_action_str(cls, arguments: dict) -> str:
+        return "Listing expense categories"
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        """List expense categories."""
+        args = ListExpenseCategoriesArgs(**kwargs)
+        categories = await self._client.list_expense_categories(limit=args.limit)
+        if not categories:
+            return ToolResult(message="No expense categories found.")
+
+        lines = [f"Found {len(categories)} expense category(ies):\n"]
+        for category in categories:
+            lines.append(str(category))
+        return ToolResult(message="\n".join(lines))
+
+
+class GetExpenseCategoryArgs(ToolArgs):
+    """Arguments for fetching a single expense category."""
+
+    category_id: str = Field(description="InvoiceNinja expense category ID.")
+
+
+class GetExpenseCategoryTool(Tool):
+    """Fetch a single expense category from InvoiceNinja."""
+
+    name = "get_expense_category"
+    description = "Fetch a single expense category from InvoiceNinja by ID."
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "category_id": {"type": "string", "description": "InvoiceNinja expense category ID."},
+        },
+        "required": ["category_id"],
+    }
+    args_model = GetExpenseCategoryArgs
+
+    @classmethod
+    def to_action_str(cls, arguments: dict) -> str:
+        return "Fetching expense category"
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        """Get an expense category."""
+        args = GetExpenseCategoryArgs(**kwargs)
+        category = await self._client.get_expense_category(args.category_id)
+        return ToolResult(message=str(category))

--- a/penny/penny/tests/plugins/invoiceninja/test_invoiceninja_plugin.py
+++ b/penny/penny/tests/plugins/invoiceninja/test_invoiceninja_plugin.py
@@ -31,10 +31,13 @@ def test_invoice_ninja_plugin_provides_tools():
     config.invoiceninja_url = "https://example.com"
     plugin = InvoiceNinjaPlugin(config)
     tools = plugin.get_tools()
-    assert len(tools) == 6
+    assert len(tools) == 9
     assert {tool.name for tool in tools} == {
         "create_expense",
+        "create_expense_category",
         "get_expense",
+        "get_expense_category",
+        "list_expense_categories",
         "list_expenses",
         "list_invoices",
         "update_expense",
@@ -252,3 +255,74 @@ async def test_update_expense_puts_only_changed_fields():
     call_args = mock_http.put.call_args
     assert call_args[0][0] == "https://invoicing.example.com/api/v1/expenses/exp1"
     assert call_args[1]["json"] == {"amount": 50.0}
+
+
+@pytest.mark.asyncio
+async def test_create_expense_category_posts_name():
+    request = httpx.Request("POST", "https://invoicing.example.com/api/v1/expense_categories")
+    with patch("penny.plugins.invoiceninja.client.httpx.AsyncClient") as mock_client_cls:
+        client = InvoiceNinjaClient(
+            api_token="test-token", base_url="https://invoicing.example.com"
+        )
+        mock_http = mock_client_cls.return_value
+        mock_http.post = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"id": "cat1", "name": "Travel"}},
+                request=request,
+            )
+        )
+        category = await client.create_expense_category("Travel")
+    assert category.id == "cat1"
+    assert category.name == "Travel"
+    mock_http.post.assert_awaited_once_with(
+        "https://invoicing.example.com/api/v1/expense_categories",
+        json={"name": "Travel"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_expense_categories_returns_parsed_categories():
+    request = httpx.Request("GET", "https://invoicing.example.com/api/v1/expense_categories")
+    with patch("penny.plugins.invoiceninja.client.httpx.AsyncClient") as mock_client_cls:
+        client = InvoiceNinjaClient(
+            api_token="test-token", base_url="https://invoicing.example.com"
+        )
+        mock_http = mock_client_cls.return_value
+        mock_http.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "cat1", "name": "Travel"}, {"id": "cat2", "name": "Meals"}]},
+                request=request,
+            )
+        )
+        categories = await client.list_expense_categories(limit=25)
+    assert len(categories) == 2
+    assert categories[0].name == "Travel"
+    mock_http.get.assert_awaited_once_with(
+        "https://invoicing.example.com/api/v1/expense_categories",
+        params={"per_page": "25"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_expense_category_fetches_by_id():
+    request = httpx.Request("GET", "https://invoicing.example.com/api/v1/expense_categories/cat1")
+    with patch("penny.plugins.invoiceninja.client.httpx.AsyncClient") as mock_client_cls:
+        client = InvoiceNinjaClient(
+            api_token="test-token", base_url="https://invoicing.example.com"
+        )
+        mock_http = mock_client_cls.return_value
+        mock_http.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"id": "cat1", "name": "Travel"}},
+                request=request,
+            )
+        )
+        category = await client.get_expense_category("cat1")
+    assert category.id == "cat1"
+    assert category.name == "Travel"
+    mock_http.get.assert_awaited_once_with(
+        "https://invoicing.example.com/api/v1/expense_categories/cat1"
+    )


### PR DESCRIPTION
# Add Invoice Ninja expense category support

## Summary

This PR adds LLM-callable tools and client methods for managing Invoice Ninja expense categories. Categories are required when creating expenses through the Invoice Ninja v5 API, so exposing them makes the existing `create_expense` workflow usable end-to-end.

## What's new

- `create_expense_category` — create a new expense category
- `list_expense_categories` — list available categories
- `get_expense_category` — fetch a single category by ID

These tools map to the endpoints documented in the Invoice Ninja API reference:

- `POST /api/v1/expense_categories`
- `GET /api/v1/expense_categories`
- `GET /api/v1/expense_categories/:id`

## Files changed

- `penny/plugins/invoiceninja/models.py`
  - Added `ExpenseCategory` Pydantic model
- `penny/plugins/invoiceninja/client.py`
  - Added `_expense_category_from_data` helper
  - Added `create_expense_category`, `list_expense_categories`, and `get_expense_category` methods
- `penny/plugins/invoiceninja/tools.py`
  - Added `CreateExpenseCategoryTool`, `ListExpenseCategoriesTool`, and `GetExpenseCategoryTool`
- `penny/plugins/invoiceninja/__init__.py`
  - Registered the three new tools (plugin now exposes 9 Invoice Ninja tools total)
- `penny/tests/plugins/invoiceninja/test_invoiceninja_plugin.py`
  - Updated expected tool count and added tests for each new category operation

## How to test

```bash
PYTHONPATH=/Users/andrew/Projects/penny:/Users/andrew/Projects/penny/penny \
  uv run pytest penny/tests/plugins/invoiceninja/test_invoiceninja_plugin.py -v
```

All 15 tests pass.

## Related documentation

- https://invoiceninja.github.io/docs/api-reference/get-expense-categorys
- https://invoiceninja.github.io/docs/api-reference/store-expense-category
- https://invoiceninja.github.io/docs/api-reference/show-expense-category
